### PR TITLE
Include year in results date directory (YY.MM.DD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ my_recorder.run()
 
 from shield_das import DataPlotter
 
-data_500C_run1 = "results/08.12/run_2_11h45/"
-data_500C_run2 = "results/08.18/run_2_09h47/"
-data_500C_run3 = "results/08.19/run_2_09h21/"
-data_500C_run4 = "results/08.25/run_1_09h07/"
+data_500C_run1 = "results/25.08.12/run_2_11h45/"
+data_500C_run2 = "results/25.08.18/run_2_09h47/"
+data_500C_run3 = "results/25.08.19/run_2_09h21/"
+data_500C_run4 = "results/25.08.25/run_1_09h07/"
 
 my_plotter = DataPlotter(
     dataset_paths=[data_500C_run1, data_500C_run2, data_500C_run3, data_500C_run4],

--- a/src/shield_das/data_recorder.py
+++ b/src/shield_das/data_recorder.py
@@ -194,7 +194,7 @@ class DataRecorder:
 
         # Get current date and time
         now = datetime.now()
-        current_date = now.strftime("%m.%d")
+        current_date = now.strftime("%y.%m.%d")
         current_time = now.strftime("%Hh%M")
 
         # Create date directory

--- a/test/test_data_recorder.py
+++ b/test/test_data_recorder.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import shutil
 import tempfile
 import threading
@@ -557,13 +558,14 @@ def test_data_recorder_creates_run_directory_in_normal_mode(temp_dir, mock_gauge
 def test_data_recorder_creates_date_subdirectory(recorder):
     """
     Test DataRecorder _create_results_directory to verify it creates a
-    date-based subdirectory (MM.DD format) under the results directory.
+    date-based subdirectory (YY.MM.DD format) under the results directory.
     """
     run_dir = recorder._create_results_directory()
     # Check that run_dir contains a date directory in the path
     path_parts = run_dir.split(os.sep)
     # Should have at least results_dir / date_dir / run_dir
     assert len(path_parts) >= 3
+    assert re.fullmatch(r"\d{2}\.\d{2}\.\d{2}", path_parts[-2])
 
 
 def test_data_recorder_increments_run_numbers(recorder):


### PR DESCRIPTION
Date folders under results/ were MM.DD, so the year existed only inside
run_metadata.json and folders from different years would collide. New
runs now record to results/YY.MM.DD/run_N_HHhMM. Existing archives have
been renamed to match.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
