### PR TITLE
Record run end_time in metadata on stop()

### DIFF
--- a/src/shield_das/data_recorder.py
+++ b/src/shield_das/data_recorder.py
@@ -432,9 +432,43 @@ class DataRecorder:
         if self.thread:
             self.thread.join(timeout=1.0)
 
+        # Record the end time of the run in the metadata file
+        self._update_metadata_with_end_time()
+
         # Clean up keyboard listeners
         if not self._is_ci_environment():
             keyboard.unhook_all()
+
+    def _update_metadata_with_end_time(self):
+        """Update the metadata file with the run end time.
+
+        Writes ``run_info.end_time`` (format ``%Y-%m-%d %H:%M:%S``) into
+        ``run_metadata.json`` in the run directory. If the metadata file is
+        missing or unreadable (e.g. stop() called before start()), a warning
+        is printed and no exception is raised.
+        """
+        end_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+        run_dir = getattr(self, "run_dir", None)
+        if run_dir is None:
+            print("Warning: no run directory; end_time not written to metadata")
+            return
+
+        metadata_path = os.path.join(run_dir, "run_metadata.json")
+
+        try:
+            with open(metadata_path) as f:
+                metadata = json.load(f)
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"Warning: could not update metadata with end_time: {exc}")
+            return
+
+        metadata["run_info"]["end_time"] = end_time
+
+        with open(metadata_path, "w") as f:
+            json.dump(metadata, f, indent=2)
+
+        print(f"Updated metadata with end_time: {end_time}")
 
     def record_data(self, labjack=None):
         """Record data from all gauges passed to recorder

--- a/test/test_data_recorder.py
+++ b/test/test_data_recorder.py
@@ -1188,6 +1188,103 @@ def test_data_recorder_metadata_update_preserves_existing_data(recorder):
     assert updated_metadata["run_info"]["run_type"] == original_run_type
 
 
+def test_data_recorder_stop_writes_end_time_to_metadata(recorder):
+    """
+    Test DataRecorder stop method to verify it writes run_info.end_time to
+    the metadata file when recording stops.
+    """
+    recorder.start()
+    time.sleep(0.05)
+
+    recorder.stop()
+
+    metadata_path = os.path.join(recorder.run_dir, "run_metadata.json")
+    with open(metadata_path) as f:
+        metadata = json.load(f)
+
+    assert "end_time" in metadata["run_info"]
+
+
+def test_data_recorder_stop_end_time_has_expected_format(recorder):
+    """
+    Test DataRecorder stop method to verify the recorded end_time uses the
+    '%Y-%m-%d %H:%M:%S' timestamp format.
+    """
+    recorder.start()
+    time.sleep(0.05)
+
+    recorder.stop()
+
+    metadata_path = os.path.join(recorder.run_dir, "run_metadata.json")
+    with open(metadata_path) as f:
+        metadata = json.load(f)
+
+    end_time = metadata["run_info"]["end_time"]
+    # Raises ValueError if the format is wrong
+    parsed = datetime.strptime(end_time, "%Y-%m-%d %H:%M:%S")
+    assert isinstance(parsed, datetime)
+
+
+def test_data_recorder_stop_end_time_preserves_existing_metadata(recorder):
+    """
+    Test DataRecorder stop method to confirm writing end_time preserves the
+    existing metadata contents.
+    """
+    recorder.start()
+    time.sleep(0.05)
+
+    recorder.stop()
+
+    metadata_path = os.path.join(recorder.run_dir, "run_metadata.json")
+    with open(metadata_path) as f:
+        metadata = json.load(f)
+
+    assert metadata["run_info"]["run_type"] == "test_mode"
+    assert "start_time" in metadata["run_info"]
+
+
+def test_data_recorder_stop_does_not_raise_when_metadata_missing(recorder):
+    """
+    Test DataRecorder stop method to verify it does not raise when the
+    metadata file has been removed before stopping.
+    """
+    recorder.start()
+    time.sleep(0.05)
+
+    os.remove(os.path.join(recorder.run_dir, "run_metadata.json"))
+
+    # Should log a warning and return without raising
+    recorder.stop()
+
+    assert not os.path.exists(os.path.join(recorder.run_dir, "run_metadata.json"))
+
+
+def test_data_recorder_stop_does_not_raise_before_start(recorder):
+    """
+    Test DataRecorder stop method to verify it does not raise when called
+    before start(), i.e. when no run directory exists yet.
+    """
+    recorder.stop()
+
+    assert recorder.stop_event.is_set()
+
+
+def test_data_recorder_stop_does_not_raise_on_corrupt_metadata(recorder):
+    """
+    Test DataRecorder stop method to verify it does not raise when the
+    metadata file contains invalid JSON.
+    """
+    recorder.start()
+    time.sleep(0.05)
+
+    metadata_path = os.path.join(recorder.run_dir, "run_metadata.json")
+    with open(metadata_path, "w") as f:
+        f.write("not valid json {")
+
+    # Should log a warning and return without raising
+    recorder.stop()
+
+
 # =============================================================================
 # Tests for Helper Methods
 # =============================================================================


### PR DESCRIPTION
DataRecorder.stop() now writes run_info.end_time
("%Y-%m-%d %H:%M:%S") into run_metadata.json, following the same
read-modify-write pattern as _update_metadata_with_valve_time. Missing
or corrupt metadata (or stop() before start()) logs a warning instead
of raising, and the path works in test_mode.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
