### PR TITLE
Add automatic run uploader to SHIELD-Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,12 @@ pressure_error = calculate_error_on_pressure_reading(pressure)
 - `evaluate_permeability_values(datasets)` - Extract permeability from multiple datasets
 
 For complete documentation and examples, see **[examples_standalone_analysis.py](examples_standalone_analysis.py)**
+
+## Automatic upload of completed runs
+
+Completed runs can be uploaded automatically from the rig computer to the
+[SHIELD-Data](https://github.com/PTTEPxMIT/SHIELD-Data) repository as pull
+requests, using the `shield-das-upload` command (an idempotent "outbox
+sweeper" suitable for a scheduled task). See
+**[docs/auto_upload.md](docs/auto_upload.md)** for setup: GitHub token,
+config file, and Windows Task Scheduler.

--- a/docs/auto_upload.md
+++ b/docs/auto_upload.md
@@ -1,0 +1,99 @@
+# Automatic run upload to SHIELD-Data
+
+`shield-das-upload` is an "outbox sweeper" that runs on the rig computer. Each
+sweep it:
+
+1. Scans the local `results/` directory for **completed** runs — runs that are
+   not test-mode (`test_run_*`), have either a `run_info.end_time` in
+   `run_metadata.json` or a `shield_data.csv` untouched for at least
+   `min_age_minutes`, and lasted at least `min_duration_minutes` (first to
+   last CSV timestamp).
+2. Normalises each run into the SHIELD-Data layout: a staged copy named
+   `YY.MM.DD_run_N_HHhMM/` with `shield_data.csv` renamed to
+   `pressure_gauge_data.csv`, `run_metadata.json` alongside it, and the
+   `backup/` directory excluded. Both old (`MM.DD`) and new (`YY.MM.DD`)
+   local date-directory formats are handled; the year for old-style
+   directories comes from `run_info.date`.
+3. Opens a pull request on
+   [PTTEPxMIT/SHIELD-Data](https://github.com/PTTEPxMIT/SHIELD-Data) adding
+   the run under `run_data/`, on a branch named `auto/run-<run_key>`.
+
+A ledger at `results/.upload_ledger.json` records the sha256 of each uploaded
+CSV, so re-running the sweep uploads nothing new. If a run's CSV content ever
+changes, the changed hash triggers a re-upload that force-updates the same
+branch (a superseding PR).
+
+The uploader is stdlib-only; it needs `git` on the PATH and a GitHub token.
+
+## Creating the GitHub token
+
+Use a **fine-grained personal access token** so the rig can touch only
+SHIELD-Data:
+
+1. GitHub → Settings → Developer settings → Fine-grained tokens →
+   *Generate new token*.
+2. **Resource owner**: `PTTEPxMIT`. **Repository access**: *Only select
+   repositories* → `SHIELD-Data`.
+3. **Repository permissions**: `Contents` → *Read and write*, and
+   `Pull requests` → *Read and write*. Nothing else.
+4. Set an expiry (maximum is about one year). Put a reminder in the lab
+   calendar — when the token expires, uploads silently stop and the sweep
+   logs authentication errors until a new token is configured.
+
+Provide the token to the uploader either via the environment variable
+`SHIELD_UPLOAD_TOKEN` (preferred) or the `token` key in the config file. The
+uploader never prints the token and strips it from any logged git output.
+
+## Config file
+
+Default location: `~/.shield_das_uploader.json` (override with `--config`).
+
+```json
+{
+  "results_dir": "C:/SHIELD/results",
+  "repo": "PTTEPxMIT/SHIELD-Data",
+  "staging_dir": "C:/SHIELD/results/.upload_staging",
+  "min_age_minutes": 30,
+  "min_duration_minutes": 5
+}
+```
+
+All keys are optional; `staging_dir` defaults to
+`<results_dir>/.upload_staging`.
+
+## Running it
+
+```bash
+shield-das-upload --dry-run   # show what would be uploaded, no network
+shield-das-upload             # sweep and open PRs
+shield-das-upload --config C:/SHIELD/uploader.json
+```
+
+## Windows Task Scheduler setup
+
+On the rig PC, schedule a sweep every 5 minutes (run from an elevated prompt):
+
+```bat
+schtasks /Create /TN "SHIELD run upload" /SC MINUTE /MO 5 ^
+    /TR "C:\path\to\python-env\Scripts\shield-das-upload.exe" /F
+```
+
+Point `/TR` at the `shield-das-upload` executable inside the Python
+environment where SHIELD_DAS is installed. Set `SHIELD_UPLOAD_TOKEN` as a
+*system* environment variable (System Properties → Environment Variables) so
+the scheduled task can see it, or put the token in the config file readable
+only by the task's user. Check the task with `schtasks /Query /TN
+"SHIELD run upload"` and remove it with `schtasks /Delete /TN
+"SHIELD run upload" /F`.
+
+Because the sweep is idempotent, a 5-minute cadence is safe: most sweeps find
+nothing to do and exit immediately.
+
+## How this interacts with SHIELD-Data CI
+
+Each upload is a normal pull request against SHIELD-Data's protected `main`,
+so SHIELD-Data's CI (validation of `run_metadata.json`, CSV checks, database
+ingestion) runs on the uploaded run before a human merges it. Nothing lands
+in `main` without review. If a run is re-uploaded after its CSV changed, the
+same `auto/run-<run_key>` branch is force-updated, so the existing PR simply
+re-runs CI on the new content rather than opening a duplicate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
+[project.scripts]
+shield-das-upload = "shield_das.uploader:main"
+
 [project.optional-dependencies]
 test = ["pytest", "pytest-cov", "numpy"]
 lint = ["ruff"]

--- a/src/shield_das/__init__.py
+++ b/src/shield_das/__init__.py
@@ -29,6 +29,15 @@ from .pressure_gauge import (
 )
 from .thermocouple import Thermocouple
 
+# Automatic upload of completed runs to SHIELD-Data
+from .uploader import (
+    UploaderConfig,
+    find_completed_runs,
+    normalize_run,
+    push_run,
+    sweep,
+)
+
 __all__ = [
     "Baratron626D_Gauge",
     "CVM211_Gauge",
@@ -37,13 +46,18 @@ __all__ = [
     "Dataset",
     "PressureGauge",
     "Thermocouple",
+    "UploaderConfig",
     "WGM701_Gauge",
     "average_pressure_after_increase",
     "calculate_error_on_pressure_reading",
     "calculate_flux_from_sample",
     "calculate_permeability_from_flux",
     "evaluate_permeability_values",
+    "find_completed_runs",
     "fit_permeability_data",
+    "normalize_run",
+    "push_run",
+    "sweep",
     "voltage_to_pressure",
     "voltage_to_temperature",
 ]

--- a/src/shield_das/uploader.py
+++ b/src/shield_das/uploader.py
@@ -1,0 +1,652 @@
+"""Outbox sweeper that uploads completed runs to the SHIELD-Data repository.
+
+Scans the local ``results/`` directory for completed (non test-mode) runs,
+normalises each run into the SHIELD-Data layout
+(``run_data/YY.MM.DD_run_N_HHhMM/`` with the CSV renamed to
+``pressure_gauge_data.csv``), and opens a pull request against
+`PTTEPxMIT/SHIELD-Data <https://github.com/PTTEPxMIT/SHIELD-Data>`_ for each
+new or changed run. A ledger file (``<results_dir>/.upload_ledger.json``)
+keyed by the sha256 of the run's CSV makes the sweep idempotent, so it is safe
+to run repeatedly from a scheduled task.
+
+Uses only the Python standard library plus the ``git`` CLI. See
+``docs/auto_upload.md`` for setup instructions (token, config file, and
+Windows Task Scheduler).
+"""
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from dataclasses import dataclass, fields
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CONFIG_PATH = os.path.join(os.path.expanduser("~"), ".shield_das_uploader.json")
+LEDGER_FILENAME = ".upload_ledger.json"
+DATA_CSV_NAME = "shield_data.csv"
+UPLOAD_CSV_NAME = "pressure_gauge_data.csv"
+METADATA_NAME = "run_metadata.json"
+TOKEN_ENV_VAR = "SHIELD_UPLOAD_TOKEN"
+
+# Date directories: old rigs use MM.DD, newer ones YY.MM.DD
+_DATE_DIR_OLD_RE = re.compile(r"^\d{2}\.\d{2}$")
+_DATE_DIR_NEW_RE = re.compile(r"^\d{2}\.\d{2}\.\d{2}$")
+# Run directories: run_<number>_<HHhMM>. Test runs are prefixed test_run_ and
+# deliberately do not match.
+_RUN_DIR_RE = re.compile(r"^run_(\d+)_(\d{1,2}h\d{2})$")
+
+
+@dataclass
+class UploaderConfig:
+    """Configuration for the run uploader.
+
+    Attributes:
+        results_dir: Local directory containing recorded runs
+            (``<date>/<run>/`` subdirectories).
+        repo: GitHub repository receiving the runs, as ``owner/name``.
+        staging_dir: Directory where normalised copies of runs are staged
+            before upload. Defaults to ``<results_dir>/.upload_staging``.
+        min_age_minutes: A run without an ``end_time`` in its metadata is
+            considered complete once its CSV has not been modified for this
+            many minutes.
+        min_duration_minutes: Runs shorter than this (first-to-last CSV
+            timestamp, in minutes) are skipped as aborted starts.
+        token: GitHub token used for pushing and opening pull requests. The
+            ``SHIELD_UPLOAD_TOKEN`` environment variable takes precedence.
+    """
+
+    results_dir: str = "results"
+    repo: str = "PTTEPxMIT/SHIELD-Data"
+    staging_dir: str | None = None
+    min_age_minutes: float = 30.0
+    min_duration_minutes: float = 5.0
+    token: str | None = None
+
+    def __post_init__(self):
+        if self.staging_dir is None:
+            self.staging_dir = os.path.join(self.results_dir, ".upload_staging")
+
+    @classmethod
+    def from_file(cls, path: str = DEFAULT_CONFIG_PATH) -> "UploaderConfig":
+        """Load configuration from a JSON file.
+
+        Args:
+            path: Path to the JSON config file. If the file does not exist,
+                defaults are used.
+
+        Returns:
+            The loaded UploaderConfig.
+        """
+        data = {}
+        if os.path.exists(path):
+            with open(path) as f:
+                data = json.load(f)
+
+        known = {f.name for f in fields(cls)}
+        unknown = set(data) - known
+        if unknown:
+            logger.warning("Ignoring unknown config keys in %s: %s", path, unknown)
+
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+
+def _read_metadata(run_dir: str) -> dict | None:
+    """Read run_metadata.json from a run directory.
+
+    Args:
+        run_dir: Path to the run directory.
+
+    Returns:
+        The parsed metadata dict, or None (with a warning logged) if the file
+        is missing or corrupt.
+    """
+    metadata_path = os.path.join(run_dir, METADATA_NAME)
+    try:
+        with open(metadata_path) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Skipping %s: unreadable metadata (%s)", run_dir, exc)
+        return None
+
+
+def _parse_timestamp(value: str) -> datetime | None:
+    """Parse a CSV RealTimestamp value.
+
+    Args:
+        value: Timestamp string, with or without milliseconds.
+
+    Returns:
+        The parsed datetime, or None if the value is not a timestamp.
+    """
+    for fmt in ("%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S"):
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def _run_duration_minutes(csv_path: str) -> float | None:
+    """Compute run duration from the first and last CSV data rows.
+
+    Only the head and tail of the file are read; the full CSV is never
+    loaded.
+
+    Args:
+        csv_path: Path to the run's data CSV.
+
+    Returns:
+        Duration in minutes, or None if it cannot be determined.
+    """
+    try:
+        with open(csv_path, "rb") as f:
+            f.readline()  # header
+            first_line = f.readline().decode("utf-8", errors="replace")
+            if not first_line.strip():
+                return None
+
+            f.seek(0, os.SEEK_END)
+            size = f.tell()
+            f.seek(max(0, size - 8192))
+            tail_lines = [
+                line
+                for line in f.read().decode("utf-8", errors="replace").splitlines()
+                if line.strip()
+            ]
+            if not tail_lines:
+                return None
+            last_line = tail_lines[-1]
+    except OSError as exc:
+        logger.warning("Could not read %s: %s", csv_path, exc)
+        return None
+
+    first_ts = _parse_timestamp(first_line.split(",", 1)[0].strip())
+    last_ts = _parse_timestamp(last_line.split(",", 1)[0].strip())
+    if first_ts is None or last_ts is None:
+        return None
+    return (last_ts - first_ts).total_seconds() / 60.0
+
+
+def find_completed_runs(
+    results_dir: str,
+    min_age_minutes: float = 30.0,
+    min_duration_minutes: float = 5.0,
+) -> Iterator[str]:
+    """Yield run directories that are complete and worth uploading.
+
+    Walks date directories in both the old ``MM.DD`` and new ``YY.MM.DD``
+    naming forms. A run qualifies when all of the following hold:
+
+    - it is not a test-mode run (``test_run_*`` directories are skipped);
+    - its metadata has ``run_info.end_time``, OR its ``shield_data.csv`` was
+      last modified more than ``min_age_minutes`` ago;
+    - its duration (first-to-last CSV timestamp) is at least
+      ``min_duration_minutes``.
+
+    Runs with missing or corrupt metadata are skipped with a warning; this
+    function never raises for a malformed run.
+
+    Args:
+        results_dir: Directory containing date-named run subdirectories.
+        min_age_minutes: Age threshold (minutes since last CSV write) used
+            when no end_time is recorded.
+        min_duration_minutes: Minimum run duration in minutes.
+
+    Yields:
+        Absolute paths of completed run directories.
+    """
+    if not os.path.isdir(results_dir):
+        logger.warning("Results directory does not exist: %s", results_dir)
+        return
+
+    for date_name in sorted(os.listdir(results_dir)):
+        date_dir = os.path.join(results_dir, date_name)
+        if not os.path.isdir(date_dir):
+            continue
+        if not (_DATE_DIR_OLD_RE.match(date_name) or _DATE_DIR_NEW_RE.match(date_name)):
+            continue
+
+        for run_name in sorted(os.listdir(date_dir)):
+            run_dir = os.path.join(date_dir, run_name)
+            if not os.path.isdir(run_dir):
+                continue
+            # test_run_* directories (test mode) never match this pattern
+            if not _RUN_DIR_RE.match(run_name):
+                continue
+
+            csv_path = os.path.join(run_dir, DATA_CSV_NAME)
+            if not os.path.isfile(csv_path):
+                logger.warning("Skipping %s: no %s", run_dir, DATA_CSV_NAME)
+                continue
+
+            metadata = _read_metadata(run_dir)
+            if metadata is None:
+                continue
+
+            run_info = metadata.get("run_info", {})
+            has_end_time = bool(run_info.get("end_time"))
+            age_minutes = (
+                datetime.now().timestamp() - os.path.getmtime(csv_path)
+            ) / 60.0
+            if not has_end_time and age_minutes < min_age_minutes:
+                logger.info(
+                    "Skipping %s: no end_time and CSV modified %.1f min ago",
+                    run_dir,
+                    age_minutes,
+                )
+                continue
+
+            duration = _run_duration_minutes(csv_path)
+            if duration is None:
+                logger.warning("Skipping %s: could not determine duration", run_dir)
+                continue
+            if duration < min_duration_minutes:
+                logger.info(
+                    "Skipping %s: duration %.1f min < %.1f min",
+                    run_dir,
+                    duration,
+                    min_duration_minutes,
+                )
+                continue
+
+            yield os.path.abspath(run_dir)
+
+
+def run_key(run_dir: str) -> str:
+    """Build the canonical SHIELD-Data key for a run directory.
+
+    The key has the form ``YY.MM.DD_run_N_HHhMM``. For old-style ``MM.DD``
+    date directories, the year is taken from ``run_info.date`` in the
+    metadata.
+
+    Args:
+        run_dir: Path to the run directory.
+
+    Returns:
+        The run key string.
+
+    Raises:
+        ValueError: If the directory name or metadata cannot be interpreted.
+    """
+    run_name = os.path.basename(os.path.normpath(run_dir))
+    if not _RUN_DIR_RE.match(run_name):
+        raise ValueError(f"Not a run directory name: {run_name!r}")
+
+    date_name = os.path.basename(os.path.dirname(os.path.normpath(run_dir)))
+    if _DATE_DIR_NEW_RE.match(date_name):
+        date_part = date_name
+    elif _DATE_DIR_OLD_RE.match(date_name):
+        metadata = _read_metadata(run_dir)
+        if metadata is None:
+            raise ValueError(f"Cannot determine year for {run_dir}: no metadata")
+        date_str = metadata.get("run_info", {}).get("date", "")
+        try:
+            year_two_digit = datetime.strptime(date_str, "%Y-%m-%d").strftime("%y")
+        except ValueError as exc:
+            raise ValueError(
+                f"Cannot determine year for {run_dir}: bad run_info.date {date_str!r}"
+            ) from exc
+        date_part = f"{year_two_digit}.{date_name}"
+    else:
+        raise ValueError(f"Unrecognised date directory name: {date_name!r}")
+
+    return f"{date_part}_{run_name}"
+
+
+def normalize_run(run_dir: str, staging_dir: str) -> str:
+    """Copy a run into the staging directory in the SHIELD-Data layout.
+
+    Creates ``<staging_dir>/YY.MM.DD_run_N_HHhMM/`` containing the run's
+    files with ``shield_data.csv`` renamed to ``pressure_gauge_data.csv``.
+    The ``backup/`` subdirectory is excluded. Any existing staged copy of the
+    same run is replaced.
+
+    Args:
+        run_dir: Path to the source run directory.
+        staging_dir: Directory in which to create the staged copy.
+
+    Returns:
+        Path to the staged run directory.
+    """
+    key = run_key(run_dir)
+    staged = os.path.join(staging_dir, key)
+    if os.path.exists(staged):
+        shutil.rmtree(staged)
+    os.makedirs(staging_dir, exist_ok=True)
+
+    shutil.copytree(run_dir, staged, ignore=shutil.ignore_patterns("backup"))
+
+    csv_src = os.path.join(staged, DATA_CSV_NAME)
+    os.replace(csv_src, os.path.join(staged, UPLOAD_CSV_NAME))
+    return staged
+
+
+def csv_sha256(run_dir: str) -> str:
+    """Compute the sha256 of a run's shield_data.csv content.
+
+    Args:
+        run_dir: Path to the run directory.
+
+    Returns:
+        Hex digest of the CSV content.
+    """
+    digest = hashlib.sha256()
+    with open(os.path.join(run_dir, DATA_CSV_NAME), "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_ledger(results_dir: str) -> dict:
+    """Load the upload ledger from the results directory.
+
+    Args:
+        results_dir: Directory containing the ``.upload_ledger.json`` file.
+
+    Returns:
+        The ledger mapping ``run_key -> {"sha256", "uploaded_at", "pr_url"}``.
+        Empty if the ledger is missing or corrupt.
+    """
+    path = os.path.join(results_dir, LEDGER_FILENAME)
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Could not read ledger %s (%s); starting fresh", path, exc)
+        return {}
+
+
+def save_ledger(results_dir: str, ledger: dict) -> None:
+    """Write the upload ledger to the results directory.
+
+    Args:
+        results_dir: Directory in which to write ``.upload_ledger.json``.
+        ledger: Ledger mapping to serialise.
+    """
+    path = os.path.join(results_dir, LEDGER_FILENAME)
+    with open(path, "w") as f:
+        json.dump(ledger, f, indent=2)
+
+
+def _get_token(config: UploaderConfig) -> str:
+    """Resolve the GitHub token from the environment or config.
+
+    Args:
+        config: Uploader configuration.
+
+    Returns:
+        The token string.
+
+    Raises:
+        RuntimeError: If no token is configured.
+    """
+    token = os.environ.get(TOKEN_ENV_VAR) or config.token
+    if not token:
+        raise RuntimeError(
+            f"No upload token: set the {TOKEN_ENV_VAR} environment variable or "
+            'the "token" key in the uploader config file'
+        )
+    return token
+
+
+def _redact(text: str, token: str) -> str:
+    """Remove the token from a string before it is logged or raised.
+
+    Args:
+        text: Text that may contain the token.
+        token: The secret to strip.
+
+    Returns:
+        The text with every occurrence of the token replaced by ``***``.
+    """
+    if not token:
+        return text
+    return text.replace(token, "***")
+
+
+def _git(args: list[str], token: str) -> None:
+    """Run a git command, raising with token-redacted output on failure.
+
+    Args:
+        args: Arguments passed to git (without the leading ``git``).
+        token: Token to redact from any surfaced output.
+
+    Raises:
+        RuntimeError: If the command exits non-zero.
+    """
+    result = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        command = _redact(" ".join(["git", *args]), token)
+        output = _redact(f"{result.stdout}\n{result.stderr}".strip(), token)
+        raise RuntimeError(f"Command failed ({command}): {output}")
+
+
+def _github_api(url: str, token: str, payload: dict | None = None) -> dict | list:
+    """Call the GitHub REST API.
+
+    Args:
+        url: Full API URL.
+        token: GitHub token for the Authorization header.
+        payload: JSON body; POSTs if given, otherwise GETs.
+
+    Returns:
+        The decoded JSON response.
+
+    Raises:
+        RuntimeError: On an HTTP error, with the token redacted.
+    """
+    data = json.dumps(payload).encode() if payload is not None else None
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        },
+        method="POST" if payload is not None else "GET",
+    )
+    try:
+        with urllib.request.urlopen(request) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as exc:
+        body = _redact(exc.read().decode("utf-8", errors="replace"), token)
+        raise RuntimeError(f"GitHub API error {exc.code} for {url}: {body}") from None
+
+
+def push_run(staged_dir: str, config: UploaderConfig) -> str:
+    """Push a staged run to SHIELD-Data and open a pull request.
+
+    Shallow-clones the target repository into a temporary directory, creates
+    (or force-updates) the branch ``auto/run-<run_key>`` containing the run
+    under ``run_data/``, pushes it, and opens a PR via the GitHub REST API.
+    If an open PR for the branch already exists, its URL is returned instead.
+
+    The token is never printed; it is stripped from any error output.
+
+    Args:
+        staged_dir: Path to a staged run directory (from normalize_run).
+        config: Uploader configuration.
+
+    Returns:
+        The URL of the pull request.
+    """
+    key = os.path.basename(os.path.normpath(staged_dir))
+    token = _get_token(config)
+    branch = f"auto/run-{key}"
+    tmp = tempfile.mkdtemp(prefix="shield_upload_")
+    try:
+        repo_dir = os.path.join(tmp, "SHIELD-Data")
+        clone_url = f"https://x-access-token:{token}@github.com/{config.repo}.git"
+        _git(["clone", "--depth", "1", clone_url, repo_dir], token)
+        _git(["-C", repo_dir, "checkout", "-b", branch], token)
+
+        dest = os.path.join(repo_dir, "run_data", key)
+        if os.path.exists(dest):
+            shutil.rmtree(dest)
+        shutil.copytree(staged_dir, dest)
+
+        _git(["-C", repo_dir, "add", "run_data"], token)
+        _git(
+            [
+                "-C",
+                repo_dir,
+                "-c",
+                "user.name=SHIELD DAS uploader",
+                "-c",
+                "user.email=shield-das-uploader@users.noreply.github.com",
+                "commit",
+                "-m",
+                f"Add run {key} (auto-upload)",
+            ],
+            token,
+        )
+        # Force so a re-upload of a changed run supersedes the old branch
+        _git(["-C", repo_dir, "push", "--force", "-u", "origin", branch], token)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    api_base = f"https://api.github.com/repos/{config.repo}"
+    try:
+        response = _github_api(
+            f"{api_base}/pulls",
+            token,
+            payload={
+                "title": f"Add run {key}",
+                "head": branch,
+                "base": "main",
+                "body": (
+                    f"Auto-uploaded from the SHIELD rig by `shield-das-upload`.\n\n"
+                    f"Run `{key}` recorded by SHIELD_DAS; CSV renamed to "
+                    f"`{UPLOAD_CSV_NAME}`, `backup/` excluded."
+                ),
+            },
+        )
+        return response.get("html_url", "")
+    except RuntimeError as exc:
+        # 422 usually means a PR for this branch already exists; reuse it
+        if "422" not in str(exc):
+            raise
+        owner = config.repo.split("/")[0]
+        existing = _github_api(
+            f"{api_base}/pulls?head={owner}:{branch}&state=open", token
+        )
+        if existing:
+            url = existing[0].get("html_url", "")
+            logger.info("PR already open for %s: %s", key, url)
+            return url
+        raise
+
+
+def sweep(config: UploaderConfig, dry_run: bool = False) -> list[str]:
+    """Find completed runs and upload any that are new or changed.
+
+    Args:
+        config: Uploader configuration.
+        dry_run: If True, print what would be uploaded and do nothing else
+            (no staging, no network).
+
+    Returns:
+        List of run keys that were uploaded (or would be, for a dry run).
+    """
+    ledger = load_ledger(config.results_dir)
+    processed = []
+
+    for run_dir in find_completed_runs(
+        config.results_dir,
+        min_age_minutes=config.min_age_minutes,
+        min_duration_minutes=config.min_duration_minutes,
+    ):
+        try:
+            key = run_key(run_dir)
+        except ValueError as exc:
+            logger.warning("Skipping %s: %s", run_dir, exc)
+            continue
+
+        sha = csv_sha256(run_dir)
+        entry = ledger.get(key)
+        if entry and entry.get("sha256") == sha:
+            logger.info("Already uploaded, unchanged: %s", key)
+            continue
+
+        if dry_run:
+            action = "re-upload (changed)" if entry else "upload"
+            print(f"[dry-run] would {action}: {key}  ({run_dir})")
+            processed.append(key)
+            continue
+
+        try:
+            staged = normalize_run(run_dir, config.staging_dir)
+            pr_url = push_run(staged, config)
+        except (OSError, RuntimeError) as exc:
+            logger.error("Upload failed for %s: %s", key, exc)
+            continue
+
+        ledger[key] = {
+            "sha256": sha,
+            "uploaded_at": datetime.now(timezone.utc).isoformat(),
+            "pr_url": pr_url,
+        }
+        save_ledger(config.results_dir, ledger)
+        logger.info("Uploaded %s -> %s", key, pr_url)
+        processed.append(key)
+
+    return processed
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the run uploader.
+
+    Args:
+        argv: Command-line arguments (defaults to sys.argv).
+
+    Returns:
+        Process exit code (0 on success).
+    """
+    parser = argparse.ArgumentParser(
+        prog="shield-das-upload",
+        description=(
+            "Upload completed SHIELD runs to the SHIELD-Data repository as "
+            "pull requests."
+        ),
+    )
+    parser.add_argument(
+        "--config",
+        default=DEFAULT_CONFIG_PATH,
+        help=f"Path to the JSON config file (default: {DEFAULT_CONFIG_PATH})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be uploaded without touching the network",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    config = UploaderConfig.from_file(args.config)
+    processed = sweep(config, dry_run=args.dry_run)
+    if not processed:
+        print("Nothing to upload.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -193,8 +193,8 @@ def test_expected_export_count():
     """Test that we have the expected number of exports."""
     import shield_das
 
-    # 8 analysis functions + 8 core classes/gauges = 16 total
-    expected_count = 16
+    # 8 analysis functions + 8 core classes/gauges + 5 uploader = 21 total
+    expected_count = 21
     actual_count = len(shield_das.__all__)
 
     assert actual_count == expected_count, (

--- a/test/test_uploader.py
+++ b/test/test_uploader.py
@@ -1,0 +1,638 @@
+"""Tests for the shield_das.uploader outbox sweeper.
+
+No network and no hardware: transport tests mock subprocess.run and
+urllib.request.urlopen.
+"""
+
+import io
+import json
+import os
+import subprocess
+import time
+from datetime import datetime, timedelta
+
+import pytest
+
+from shield_das import uploader
+from shield_das.uploader import (
+    UploaderConfig,
+    csv_sha256,
+    find_completed_runs,
+    load_ledger,
+    normalize_run,
+    push_run,
+    run_key,
+    sweep,
+)
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+RUN_START = datetime(2025, 8, 1, 10, 0, 0)
+
+
+def make_run(
+    results_dir,
+    date_dir="25.08.01",
+    run_name="run_1_10h00",
+    date="2025-08-01",
+    end_time=None,
+    duration_minutes=10.0,
+    with_metadata=True,
+    corrupt_metadata=False,
+    with_backup=False,
+    stale=True,
+):
+    """Create a fake run directory and return its path.
+
+    Args:
+        results_dir: Root results directory.
+        date_dir: Name of the date directory (MM.DD or YY.MM.DD form).
+        run_name: Name of the run directory.
+        date: run_info.date value (%Y-%m-%d).
+        end_time: run_info.end_time value, omitted if None.
+        duration_minutes: Span between first and last CSV timestamps.
+        with_metadata: Whether to write run_metadata.json.
+        corrupt_metadata: Write invalid JSON as metadata.
+        with_backup: Create a backup/ subdirectory with a file.
+        stale: Backdate the CSV mtime by 2 hours.
+    """
+    run_dir = os.path.join(results_dir, date_dir, run_name)
+    os.makedirs(run_dir)
+
+    end = RUN_START + timedelta(minutes=duration_minutes)
+    csv_lines = [
+        "RealTimestamp,TestGauge_Voltage (V)",
+        f"{RUN_START:%Y-%m-%d %H:%M:%S}.000,5.0",
+        f"{RUN_START + timedelta(minutes=duration_minutes / 2):%Y-%m-%d %H:%M:%S}"
+        ".000,5.1",
+        f"{end:%Y-%m-%d %H:%M:%S}.000,5.2",
+    ]
+    csv_path = os.path.join(run_dir, "shield_data.csv")
+    with open(csv_path, "w") as f:
+        f.write("\n".join(csv_lines) + "\n")
+
+    if corrupt_metadata:
+        with open(os.path.join(run_dir, "run_metadata.json"), "w") as f:
+            f.write("not valid json {")
+    elif with_metadata:
+        run_info = {
+            "date": date,
+            "start_time": f"{date} 10:00:00",
+            "run_type": "permeation_exp",
+            "data_filename": "shield_data.csv",
+        }
+        if end_time is not None:
+            run_info["end_time"] = end_time
+        with open(os.path.join(run_dir, "run_metadata.json"), "w") as f:
+            json.dump({"version": "1.3", "run_info": run_info}, f)
+
+    if with_backup:
+        backup_dir = os.path.join(run_dir, "backup")
+        os.makedirs(backup_dir)
+        with open(os.path.join(backup_dir, "shield_data_backup_data_1.csv"), "w") as f:
+            f.write("backup contents\n")
+
+    if stale:
+        old = time.time() - 2 * 3600
+        os.utime(csv_path, (old, old))
+
+    return run_dir
+
+
+@pytest.fixture
+def results_dir(tmp_path):
+    """Root results directory for fake runs."""
+    path = tmp_path / "results"
+    path.mkdir()
+    return str(path)
+
+
+@pytest.fixture
+def staging_dir(tmp_path):
+    """Staging directory for normalised runs."""
+    return str(tmp_path / "staging")
+
+
+@pytest.fixture
+def config(results_dir, staging_dir):
+    """UploaderConfig pointing at the temp results/staging directories."""
+    return UploaderConfig(
+        results_dir=results_dir,
+        staging_dir=staging_dir,
+        min_age_minutes=30.0,
+        min_duration_minutes=5.0,
+    )
+
+
+# =============================================================================
+# Tests for completion detection
+# =============================================================================
+
+
+def test_find_completed_runs_detects_run_with_end_time(results_dir):
+    """A run whose metadata has end_time is complete even with a fresh CSV."""
+    run_dir = make_run(results_dir, end_time="2025-08-01 10:10:00", stale=False)
+    found = list(find_completed_runs(results_dir))
+    assert found == [os.path.abspath(run_dir)]
+
+
+def test_find_completed_runs_skips_fresh_run_without_end_time(results_dir):
+    """A run without end_time whose CSV was just written is not complete."""
+    make_run(results_dir, stale=False)
+    assert list(find_completed_runs(results_dir)) == []
+
+
+def test_find_completed_runs_detects_stale_run_without_end_time(results_dir):
+    """A run without end_time is complete once its CSV mtime is old enough."""
+    run_dir = make_run(results_dir, stale=True)
+    found = list(find_completed_runs(results_dir, min_age_minutes=30))
+    assert found == [os.path.abspath(run_dir)]
+
+
+def test_find_completed_runs_skips_too_short_run(results_dir):
+    """Runs shorter than min_duration_minutes are skipped."""
+    make_run(results_dir, end_time="2025-08-01 10:02:00", duration_minutes=2.0)
+    assert list(find_completed_runs(results_dir, min_duration_minutes=5)) == []
+
+
+def test_find_completed_runs_skips_test_runs(results_dir):
+    """test_run_* directories (test mode) are never uploaded."""
+    make_run(
+        results_dir,
+        run_name="test_run_1_10h00",
+        end_time="2025-08-01 10:10:00",
+    )
+    assert list(find_completed_runs(results_dir)) == []
+
+
+def test_find_completed_runs_skips_missing_metadata(results_dir, caplog):
+    """A run without run_metadata.json is skipped with a warning, not raised."""
+    make_run(results_dir, with_metadata=False)
+    assert list(find_completed_runs(results_dir)) == []
+    assert "unreadable metadata" in caplog.text
+
+
+def test_find_completed_runs_skips_corrupt_metadata(results_dir, caplog):
+    """A run with invalid JSON metadata is skipped with a warning, not raised."""
+    make_run(results_dir, corrupt_metadata=True)
+    assert list(find_completed_runs(results_dir)) == []
+    assert "unreadable metadata" in caplog.text
+
+
+def test_find_completed_runs_walks_both_date_dir_formats(results_dir):
+    """Both MM.DD and YY.MM.DD date directories are scanned."""
+    old_style = make_run(results_dir, date_dir="08.01", end_time="2025-08-01 10:10:00")
+    new_style = make_run(
+        results_dir, date_dir="25.08.02", end_time="2025-08-02 10:10:00"
+    )
+    found = list(find_completed_runs(results_dir))
+    assert sorted(found) == sorted(
+        [os.path.abspath(old_style), os.path.abspath(new_style)]
+    )
+
+
+def test_find_completed_runs_ignores_unrelated_directories(results_dir):
+    """Non-date directories and stray files are ignored."""
+    os.makedirs(os.path.join(results_dir, "notes"))
+    with open(os.path.join(results_dir, "readme.txt"), "w") as f:
+        f.write("hello")
+    assert list(find_completed_runs(results_dir)) == []
+
+
+def test_find_completed_runs_missing_results_dir_does_not_raise(tmp_path):
+    """A nonexistent results directory yields nothing rather than raising."""
+    assert list(find_completed_runs(str(tmp_path / "nope"))) == []
+
+
+# =============================================================================
+# Tests for run_key and normalization
+# =============================================================================
+
+
+def test_run_key_uses_new_style_date_dir_directly(results_dir):
+    """YY.MM.DD date directories map straight into the run key."""
+    run_dir = make_run(results_dir, date_dir="25.08.01")
+    assert run_key(run_dir) == "25.08.01_run_1_10h00"
+
+
+def test_run_key_adds_year_from_metadata_for_old_style_dir(results_dir):
+    """MM.DD date directories get the year from run_info.date."""
+    run_dir = make_run(results_dir, date_dir="08.01", date="2025-08-01")
+    assert run_key(run_dir) == "25.08.01_run_1_10h00"
+
+
+def test_run_key_raises_for_old_style_dir_without_metadata(results_dir):
+    """Old-style dirs need metadata for the year; missing metadata raises."""
+    run_dir = make_run(results_dir, date_dir="08.01", with_metadata=False)
+    with pytest.raises(ValueError, match="Cannot determine year"):
+        run_key(run_dir)
+
+
+def test_normalize_run_creates_staged_directory(results_dir, staging_dir):
+    """The staged directory is named YY.MM.DD_run_N_HHhMM."""
+    run_dir = make_run(results_dir)
+    staged = normalize_run(run_dir, staging_dir)
+    assert os.path.basename(staged) == "25.08.01_run_1_10h00"
+    assert os.path.isdir(staged)
+
+
+def test_normalize_run_renames_csv(results_dir, staging_dir):
+    """shield_data.csv is renamed to pressure_gauge_data.csv."""
+    run_dir = make_run(results_dir)
+    staged = normalize_run(run_dir, staging_dir)
+    assert os.path.isfile(os.path.join(staged, "pressure_gauge_data.csv"))
+    assert not os.path.exists(os.path.join(staged, "shield_data.csv"))
+
+
+def test_normalize_run_copies_metadata(results_dir, staging_dir):
+    """run_metadata.json is copied into the staged directory."""
+    run_dir = make_run(results_dir)
+    staged = normalize_run(run_dir, staging_dir)
+    assert os.path.isfile(os.path.join(staged, "run_metadata.json"))
+
+
+def test_normalize_run_excludes_backup_directory(results_dir, staging_dir):
+    """The backup/ subdirectory is not copied into staging."""
+    run_dir = make_run(results_dir, with_backup=True)
+    staged = normalize_run(run_dir, staging_dir)
+    assert not os.path.exists(os.path.join(staged, "backup"))
+
+
+def test_normalize_run_handles_old_style_date_dir(results_dir, staging_dir):
+    """Old MM.DD runs are staged under the full YY.MM.DD key."""
+    run_dir = make_run(results_dir, date_dir="08.01", date="2025-08-01")
+    staged = normalize_run(run_dir, staging_dir)
+    assert os.path.basename(staged) == "25.08.01_run_1_10h00"
+
+
+def test_normalize_run_replaces_existing_staged_copy(results_dir, staging_dir):
+    """Re-normalising a run replaces any previous staged copy."""
+    run_dir = make_run(results_dir)
+    staged_first = normalize_run(run_dir, staging_dir)
+    marker = os.path.join(staged_first, "stale_file.txt")
+    with open(marker, "w") as f:
+        f.write("left over")
+    staged_second = normalize_run(run_dir, staging_dir)
+    assert staged_second == staged_first
+    assert not os.path.exists(marker)
+
+
+# =============================================================================
+# Tests for ledger idempotency
+# =============================================================================
+
+
+def _patch_transport(monkeypatch, calls):
+    """Replace push_run in the module with a recorder returning a fake URL."""
+
+    def fake_push_run(staged_dir, config):
+        calls.append(staged_dir)
+        return "https://github.com/PTTEPxMIT/SHIELD-Data/pull/1"
+
+    monkeypatch.setattr(uploader, "push_run", fake_push_run)
+
+
+def test_sweep_uploads_new_run_and_records_ledger(config, monkeypatch):
+    """A new completed run is uploaded and recorded in the ledger."""
+    calls = []
+    _patch_transport(monkeypatch, calls)
+    make_run(config.results_dir, end_time="2025-08-01 10:10:00")
+
+    uploaded = sweep(config)
+
+    assert uploaded == ["25.08.01_run_1_10h00"]
+    assert len(calls) == 1
+    ledger = load_ledger(config.results_dir)
+    entry = ledger["25.08.01_run_1_10h00"]
+    assert entry["pr_url"] == "https://github.com/PTTEPxMIT/SHIELD-Data/pull/1"
+    assert "sha256" in entry
+    assert "uploaded_at" in entry
+
+
+def test_sweep_is_idempotent_for_unchanged_run(config, monkeypatch):
+    """A second sweep with an unchanged CSV uploads nothing."""
+    calls = []
+    _patch_transport(monkeypatch, calls)
+    make_run(config.results_dir, end_time="2025-08-01 10:10:00")
+
+    assert sweep(config) == ["25.08.01_run_1_10h00"]
+    assert sweep(config) == []
+    assert len(calls) == 1
+
+
+def test_sweep_reuploads_when_csv_changes(config, monkeypatch):
+    """A changed CSV hash triggers a re-upload (superseding PR)."""
+    calls = []
+    _patch_transport(monkeypatch, calls)
+    run_dir = make_run(config.results_dir, end_time="2025-08-01 10:10:00")
+    sweep(config)
+
+    csv_path = os.path.join(run_dir, "shield_data.csv")
+    with open(csv_path, "a") as f:
+        f.write("2025-08-01 10:11:00.000,5.3\n")
+    old = time.time() - 2 * 3600
+    os.utime(csv_path, (old, old))
+
+    assert sweep(config) == ["25.08.01_run_1_10h00"]
+    assert len(calls) == 2
+
+
+def test_sweep_continues_after_failed_upload(config, monkeypatch, caplog):
+    """A transport failure for one run is logged and does not abort the sweep."""
+
+    def failing_push_run(staged_dir, config):
+        raise RuntimeError("push failed")
+
+    monkeypatch.setattr(uploader, "push_run", failing_push_run)
+    make_run(config.results_dir, end_time="2025-08-01 10:10:00")
+
+    assert sweep(config) == []
+    assert "Upload failed" in caplog.text
+    assert load_ledger(config.results_dir) == {}
+
+
+def test_csv_sha256_changes_with_content(config):
+    """The ledger hash tracks CSV content."""
+    run_dir = make_run(config.results_dir, end_time="2025-08-01 10:10:00")
+    before = csv_sha256(run_dir)
+    with open(os.path.join(run_dir, "shield_data.csv"), "a") as f:
+        f.write("2025-08-01 10:11:00.000,5.3\n")
+    assert csv_sha256(run_dir) != before
+
+
+# =============================================================================
+# Tests for dry-run and CLI
+# =============================================================================
+
+
+def test_sweep_dry_run_prints_without_uploading(config, monkeypatch, capsys):
+    """Dry-run reports the run but performs no staging, transport, or ledger."""
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("transport must not run during dry-run")
+
+    monkeypatch.setattr(uploader, "push_run", forbidden)
+    monkeypatch.setattr(subprocess, "run", forbidden)
+    make_run(config.results_dir, end_time="2025-08-01 10:10:00")
+
+    uploaded = sweep(config, dry_run=True)
+
+    assert uploaded == ["25.08.01_run_1_10h00"]
+    out = capsys.readouterr().out
+    assert "would upload: 25.08.01_run_1_10h00" in out
+    assert not os.path.exists(config.staging_dir)
+    assert load_ledger(config.results_dir) == {}
+
+
+def test_main_dry_run_with_config_file(tmp_path, results_dir, monkeypatch, capsys):
+    """The CLI loads the config file and honours --dry-run."""
+    make_run(results_dir, end_time="2025-08-01 10:10:00")
+    config_path = tmp_path / "uploader_config.json"
+    config_path.write_text(
+        json.dumps({"results_dir": results_dir, "min_duration_minutes": 5})
+    )
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("no network during dry-run")
+
+    monkeypatch.setattr(subprocess, "run", forbidden)
+
+    exit_code = uploader.main(["--config", str(config_path), "--dry-run"])
+
+    assert exit_code == 0
+    assert "25.08.01_run_1_10h00" in capsys.readouterr().out
+
+
+def test_main_reports_nothing_to_upload(tmp_path, results_dir, capsys):
+    """The CLI reports when no completed runs are found."""
+    config_path = tmp_path / "uploader_config.json"
+    config_path.write_text(json.dumps({"results_dir": results_dir}))
+
+    exit_code = uploader.main(["--config", str(config_path), "--dry-run"])
+
+    assert exit_code == 0
+    assert "Nothing to upload" in capsys.readouterr().out
+
+
+def test_uploader_config_defaults_staging_dir():
+    """staging_dir defaults to a hidden directory inside results_dir."""
+    cfg = UploaderConfig(results_dir="some_results")
+    assert cfg.staging_dir == os.path.join("some_results", ".upload_staging")
+
+
+def test_uploader_config_from_missing_file_uses_defaults(tmp_path):
+    """Loading from a nonexistent path returns default configuration."""
+    cfg = UploaderConfig.from_file(str(tmp_path / "absent.json"))
+    assert cfg.repo == "PTTEPxMIT/SHIELD-Data"
+    assert cfg.min_age_minutes == 30.0
+
+
+def test_uploader_config_from_file_ignores_unknown_keys(tmp_path, caplog):
+    """Unknown config keys are ignored with a warning."""
+    path = tmp_path / "cfg.json"
+    path.write_text(json.dumps({"repo": "other/repo", "bogus_key": 1}))
+    cfg = UploaderConfig.from_file(str(path))
+    assert cfg.repo == "other/repo"
+    assert "bogus_key" in caplog.text
+
+
+# =============================================================================
+# Tests for transport (mocked subprocess + urllib)
+# =============================================================================
+
+TOKEN = "ghp_SECRETTOKEN12345"
+
+
+@pytest.fixture
+def staged_run(results_dir, staging_dir):
+    """A normalised staged run ready for transport."""
+    run_dir = make_run(results_dir, end_time="2025-08-01 10:10:00")
+    return normalize_run(run_dir, staging_dir)
+
+
+def _fake_urlopen_factory(responses):
+    """Build a fake urlopen returning queued JSON payloads."""
+
+    def fake_urlopen(request):
+        responses.setdefault("requests", []).append(request)
+        payload = responses["queue"].pop(0)
+        return io.BytesIO(json.dumps(payload).encode())
+
+    return fake_urlopen
+
+
+def test_push_run_clones_branches_commits_and_pushes(config, staged_run, monkeypatch):
+    """push_run drives git through clone, branch, add, commit, and push."""
+    monkeypatch.setenv("SHIELD_UPLOAD_TOKEN", TOKEN)
+    git_calls = []
+
+    def fake_run(cmd, **kwargs):
+        git_calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    responses = {"queue": [{"html_url": "https://example.test/pull/7"}]}
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        uploader.urllib.request, "urlopen", _fake_urlopen_factory(responses)
+    )
+
+    pr_url = push_run(staged_run, config)
+
+    assert pr_url == "https://example.test/pull/7"
+    subcommands = [cmd[1] if cmd[1] != "-C" else cmd[3] for cmd in git_calls]
+    assert subcommands[0] == "clone"
+    assert "checkout" in subcommands
+    assert "add" in subcommands
+    assert "push" in subcommands
+    commit_cmd = next(cmd for cmd in git_calls if "commit" in cmd)
+    assert "Add run 25.08.01_run_1_10h00 (auto-upload)" in commit_cmd
+    clone_cmd = git_calls[0]
+    assert any(TOKEN in part for part in clone_cmd)  # token used for auth
+    branch_cmd = next(cmd for cmd in git_calls if "checkout" in cmd)
+    assert "auto/run-25.08.01_run_1_10h00" in branch_cmd
+
+
+def test_push_run_opens_pr_with_expected_payload(config, staged_run, monkeypatch):
+    """The PR request targets the repo with the right title, head, and base."""
+    monkeypatch.setenv("SHIELD_UPLOAD_TOKEN", TOKEN)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0, "", ""),
+    )
+    responses = {"queue": [{"html_url": "https://example.test/pull/7"}]}
+    monkeypatch.setattr(
+        uploader.urllib.request, "urlopen", _fake_urlopen_factory(responses)
+    )
+
+    push_run(staged_run, config)
+
+    request = responses["requests"][0]
+    assert "api.github.com/repos/PTTEPxMIT/SHIELD-Data/pulls" in request.full_url
+    payload = json.loads(request.data.decode())
+    assert payload["title"] == "Add run 25.08.01_run_1_10h00"
+    assert payload["head"] == "auto/run-25.08.01_run_1_10h00"
+    assert payload["base"] == "main"
+    assert "auto-uploaded" in payload["body"].lower()
+
+
+def test_push_run_copies_run_into_run_data(config, staged_run, monkeypatch):
+    """The staged run is committed under run_data/<run_key>/ in the clone."""
+    monkeypatch.setenv("SHIELD_UPLOAD_TOKEN", TOKEN)
+    seen = {}
+
+    def fake_run(cmd, **kwargs):
+        if "add" in cmd:
+            repo_dir = cmd[cmd.index("-C") + 1]
+            staged_copy = os.path.join(repo_dir, "run_data", "25.08.01_run_1_10h00")
+            seen["csv"] = os.path.isfile(
+                os.path.join(staged_copy, "pressure_gauge_data.csv")
+            )
+            seen["metadata"] = os.path.isfile(
+                os.path.join(staged_copy, "run_metadata.json")
+            )
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    responses = {"queue": [{"html_url": "https://example.test/pull/7"}]}
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        uploader.urllib.request, "urlopen", _fake_urlopen_factory(responses)
+    )
+
+    push_run(staged_run, config)
+
+    assert seen == {"csv": True, "metadata": True}
+
+
+def test_push_run_never_exposes_token_on_git_failure(
+    config, staged_run, monkeypatch, caplog
+):
+    """A failing git command surfaces redacted output, never the token."""
+    monkeypatch.setenv("SHIELD_UPLOAD_TOKEN", TOKEN)
+
+    def failing_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            cmd,
+            128,
+            stdout="",
+            stderr=f"fatal: could not read from "
+            f"https://x-access-token:{TOKEN}@github.com/x/y.git",
+        )
+
+    monkeypatch.setattr(subprocess, "run", failing_run)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        push_run(staged_run, config)
+
+    assert TOKEN not in str(excinfo.value)
+    assert "***" in str(excinfo.value)
+    assert TOKEN not in caplog.text
+
+
+def test_push_run_never_exposes_token_on_api_failure(
+    config, staged_run, monkeypatch, caplog
+):
+    """A GitHub API error surfaces with the token redacted."""
+    monkeypatch.setenv("SHIELD_UPLOAD_TOKEN", TOKEN)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0, "", ""),
+    )
+
+    def failing_urlopen(request):
+        raise uploader.urllib.error.HTTPError(
+            request.full_url,
+            401,
+            "Unauthorized",
+            {},
+            io.BytesIO(f"bad credentials: {TOKEN}".encode()),
+        )
+
+    monkeypatch.setattr(uploader.urllib.request, "urlopen", failing_urlopen)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        push_run(staged_run, config)
+
+    assert TOKEN not in str(excinfo.value)
+    assert TOKEN not in caplog.text
+
+
+def test_push_run_requires_token(config, staged_run, monkeypatch):
+    """push_run raises a clear error when no token is configured."""
+    monkeypatch.delenv("SHIELD_UPLOAD_TOKEN", raising=False)
+    config.token = None
+
+    with pytest.raises(RuntimeError, match="No upload token"):
+        push_run(staged_run, config)
+
+
+def test_push_run_reuses_existing_pr_on_422(config, staged_run, monkeypatch):
+    """If the PR already exists (422), the existing PR URL is returned."""
+    monkeypatch.setenv("SHIELD_UPLOAD_TOKEN", TOKEN)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0, "", ""),
+    )
+    calls = {"n": 0}
+
+    def urlopen_422_then_list(request):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise uploader.urllib.error.HTTPError(
+                request.full_url,
+                422,
+                "Unprocessable",
+                {},
+                io.BytesIO(b'{"message": "A pull request already exists"}'),
+            )
+        return io.BytesIO(
+            json.dumps([{"html_url": "https://example.test/pull/3"}]).encode()
+        )
+
+    monkeypatch.setattr(uploader.urllib.request, "urlopen", urlopen_422_then_list)
+
+    assert push_run(staged_run, config) == "https://example.test/pull/3"


### PR DESCRIPTION
## Summary
- New stdlib-only `shield_das.uploader` module: an idempotent "outbox sweeper" for the rig PC that finds completed runs, normalises them into the SHIELD-Data layout, and opens a PR on PTTEPxMIT/SHIELD-Data for each new or changed run
- Completion detection: `run_info.end_time` in metadata OR stale CSV mtime, minimum run duration from first/last CSV timestamps (cheap head/tail read), `test_run_*` and malformed runs skipped with warnings; handles both `MM.DD` and `YY.MM.DD` date directories
- Normalisation: staged as `YY.MM.DD_run_N_HHhMM/`, `shield_data.csv` renamed to `pressure_gauge_data.csv`, `backup/` excluded
- Transport: shallow clone, branch `auto/run-<run_key>`, commit, force-push, PR via GitHub REST API; token from `SHIELD_UPLOAD_TOKEN` or config file, never printed and redacted from all surfaced output
- Ledger `results/.upload_ledger.json` (sha256 of CSV) makes repeated sweeps no-ops; a changed CSV re-uploads on the same branch (superseding PR)
- `shield-das-upload` console script with `--config` / `--dry-run`; docs in `docs/auto_upload.md` (token creation, config, Windows Task Scheduler, SHIELD-Data CI notes), linked from README

## Test plan
- [x] `test/test_uploader.py`: completion detection, both date-dir formats, normalisation, ledger idempotency and changed-hash re-upload, dry-run, transport with mocked `subprocess.run`/`urllib` including token-redaction assertions
- [x] Full `test_uploader.py` + `test_data_recorder.py` + `test_init.py` pass locally (146 passed)
- [x] `ruff format` / `ruff check` clean on changed files
- [x] Manual CLI dry-run smoke test against a fake run directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)