### PR TITLE
Add live run dashboard (shield-das-live)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,15 @@ pressure_error = calculate_error_on_pressure_reading(pressure)
 
 For complete documentation and examples, see **[examples_standalone_analysis.py](examples_standalone_analysis.py)**
 
+## Live run dashboard
+
+While a run is being recorded, `shield-das-live --watch` serves a lightweight
+dashboard for it: upstream/downstream pressure (torr, log scale) and
+temperature on a shared time axis, refreshed by tailing the run's CSV
+incrementally. It binds the LAN by default so the same URL can be viewed
+remotely (e.g. over Tailscale). See
+**[docs/live_dashboard.md](docs/live_dashboard.md)**.
+
 ## Automatic upload of completed runs
 
 Completed runs can be uploaded automatically from the rig computer to the

--- a/docs/auto_upload.md
+++ b/docs/auto_upload.md
@@ -18,6 +18,11 @@ sweep it:
    [PTTEPxMIT/SHIELD-Data](https://github.com/PTTEPxMIT/SHIELD-Data) adding
    the run under `run_data/`, on a branch named `auto/run-<run_key>`.
 
+Runs that are still *in progress* are not the uploader's job — watch those
+live with `shield-das-live` instead (see
+[live_dashboard.md](live_dashboard.md)); once the run ends, the next sweep
+picks it up.
+
 A ledger at `results/.upload_ledger.json` records the sha256 of each uploaded
 CSV, so re-running the sweep uploads nothing new. If a run's CSV content ever
 changes, the changed hash triggers a re-upload that force-updates the same

--- a/docs/live_dashboard.md
+++ b/docs/live_dashboard.md
@@ -1,0 +1,83 @@
+# Live run dashboard
+
+`shield-das-live` serves a small web dashboard for the run that is *currently
+being recorded*. It finds the newest run under `results/` with no
+`end_time` in its metadata and a recently written `shield_data.csv`, tails
+the CSV, and shows three stacked plots on a shared time axis:
+
+- **Upstream pressure** (torr, log scale) — all gauges with
+  `gauge_location: "upstream"`, converted with the existing per-gauge
+  voltage-to-pressure functions.
+- **Downstream pressure** (torr, log scale) — same for `"downstream"`.
+- **Temperature** (°C) — thermocouple voltage with cold-junction
+  compensation, when the run has a thermocouple.
+
+A header bar shows the run id, a LIVE / WAITING / ENDED status badge, the
+elapsed time, the row count, and a fidelity dropdown. When the current run
+ends (its metadata gains an `end_time`, or the CSV stops being written), the
+badge switches to ENDED and the dashboard automatically attaches to any
+newer run that starts.
+
+## Pulling it up when a run is live
+
+```bash
+shield-das-live --watch
+```
+
+`--watch` polls every 10 seconds until an active run appears, then opens the
+dashboard in your browser. Without `--watch`, the command exits with a
+message if nothing is live right now.
+
+Other options:
+
+```bash
+shield-das-live --results-dir results   # where runs are recorded
+shield-das-live --port 8051             # serve port (default 8051)
+shield-das-live --host 127.0.0.1        # local-only (default 0.0.0.0)
+shield-das-live --interval 2000         # refresh interval, ms
+shield-das-live --max-points 2000       # default plot fidelity
+shield-das-live --no-browser            # don't open a browser
+shield-das-live --include-test-runs     # also monitor test_run_* dirs
+```
+
+`--include-test-runs` is handy for demoing the dashboard without hardware:
+start a recorder with `run_type="test_mode"` and the dashboard will pick up
+the resulting `test_run_*` directory.
+
+## Keeping it always armed on the rig PC
+
+Register a logon task on the rig PC so the dashboard is waiting whenever a
+run starts (no elevation needed for a per-user logon task):
+
+```bat
+schtasks /Create /TN "SHIELD live dashboard" /SC ONLOGON ^
+    /TR "C:\path\to\python-env\Scripts\shield-das-live.exe --watch --no-browser" /F
+```
+
+Point `/TR` at the `shield-das-live` executable inside the Python
+environment where SHIELD_DAS is installed, and add
+`--results-dir C:\path\to\results` if the task does not start in the
+recorder's working directory. Check it with `schtasks /Query /TN
+"SHIELD live dashboard"` and remove it with `schtasks /Delete /TN
+"SHIELD live dashboard" /F`.
+
+## Remote viewing
+
+By default the server binds `0.0.0.0`, so the dashboard is reachable from
+other machines on the LAN or tailnet at `http://<rig-hostname>:8051` — open
+the same URL from your laptop or phone via Tailscale or the lab network. On
+a slow link, drop the fidelity dropdown to 500 points to shrink each
+refresh. Use `--host 127.0.0.1` if you want the dashboard local-only.
+
+## Why it stays cheap
+
+Two things keep the dashboard light no matter how long a run gets:
+
+- **Incremental reads** — the CSV is read once at attach time; every later
+  refresh seeks to the stored byte offset and reads only newly appended
+  lines (a half-written trailing line is buffered until it completes). The
+  file is never re-parsed from the top, unlike the main `DataPlotter` UI.
+- **Capped point budget** — each trace is decimated by stride to the
+  fidelity dropdown's limit (500 / 2000 / 5000 points), always keeping the
+  most recent sample. Browser payload per refresh is therefore constant
+  regardless of run size.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 ]
 
 [project.scripts]
+shield-das-live = "shield_das.live_dashboard:main"
 shield-das-upload = "shield_das.uploader:main"
 
 [project.optional-dependencies]

--- a/src/shield_das/__init__.py
+++ b/src/shield_das/__init__.py
@@ -21,6 +21,17 @@ from .analysis import (
 from .data_plotter import DataPlotter
 from .data_recorder import DataRecorder
 from .dataset import Dataset
+
+# Live dashboard for the run currently being recorded
+from .live_dashboard import (
+    DashboardState,
+    IncrementalRunReader,
+    LiveDashboardConfig,
+    build_traces,
+    create_app,
+    find_active_run,
+    update_dashboard,
+)
 from .pressure_gauge import (
     Baratron626D_Gauge,
     CVM211_Gauge,
@@ -41,23 +52,30 @@ from .uploader import (
 __all__ = [
     "Baratron626D_Gauge",
     "CVM211_Gauge",
+    "DashboardState",
     "DataPlotter",
     "DataRecorder",
     "Dataset",
+    "IncrementalRunReader",
+    "LiveDashboardConfig",
     "PressureGauge",
     "Thermocouple",
     "UploaderConfig",
     "WGM701_Gauge",
     "average_pressure_after_increase",
+    "build_traces",
     "calculate_error_on_pressure_reading",
     "calculate_flux_from_sample",
     "calculate_permeability_from_flux",
+    "create_app",
     "evaluate_permeability_values",
+    "find_active_run",
     "find_completed_runs",
     "fit_permeability_data",
     "normalize_run",
     "push_run",
     "sweep",
+    "update_dashboard",
     "voltage_to_pressure",
     "voltage_to_temperature",
 ]

--- a/src/shield_das/live_dashboard.py
+++ b/src/shield_das/live_dashboard.py
@@ -1,0 +1,830 @@
+"""Live run dashboard for the SHIELD rig.
+
+Serves a small Dash app (``shield-das-live``) that automatically finds the run
+currently being recorded under ``results/``, tails its ``shield_data.csv``
+incrementally (never re-reading the whole file), and shows three stacked plots
+sharing a time axis: upstream pressure (torr, log scale), downstream pressure
+(torr, log scale), and temperature (°C). Voltage-to-pressure conversion reuses
+the existing per-gauge functions; browser payload is capped by stride-based
+decimation so remote viewing over a slow link stays cheap regardless of run
+length. See ``docs/live_dashboard.md``.
+"""
+
+import argparse
+import json
+import os
+import re
+import threading
+import time
+import webbrowser
+from dataclasses import dataclass, field
+from datetime import datetime
+
+import dash
+import dash_bootstrap_components as dbc
+import numpy as np
+import plotly.graph_objects as go
+from dash import dcc, html
+from dash.dependencies import Input, Output
+from numpy.typing import NDArray
+from plotly.subplots import make_subplots
+
+from .analysis import voltage_to_pressure, voltage_to_temperature
+from .pressure_gauge import CVM211_Gauge, WGM701_Gauge
+
+DATA_CSV_NAME = "shield_data.csv"
+METADATA_NAME = "run_metadata.json"
+TIMESTAMP_COLUMN = "RealTimestamp"
+LOCAL_TEMPERATURE_COLUMN = "Local_temperature (C)"
+
+# Date directories: old rigs use MM.DD, newer ones YY.MM.DD
+_DATE_DIR_RE = re.compile(r"^\d{2}\.\d{2}(\.\d{2})?$")
+# Run directories: run_<N>_<HHhMM>, with an optional test_run_ prefix
+_RUN_DIR_RE = re.compile(r"^(test_)?run_\d+_\d{1,2}h\d{2}$")
+
+# Fidelity options offered by the max-points dropdown
+MAX_POINTS_OPTIONS = [500, 2000, 5000]
+
+
+def _parse_timestamp(value: str) -> datetime | None:
+    """Parse a CSV RealTimestamp value.
+
+    Args:
+        value: Timestamp string ("%Y-%m-%d %H:%M:%S" with optional
+            fractional seconds).
+
+    Returns:
+        The parsed datetime, or None if the value is not a timestamp.
+    """
+    for fmt in ("%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S"):
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def _read_metadata(run_dir: str) -> dict | None:
+    """Read run_metadata.json from a run directory.
+
+    Args:
+        run_dir: Path to the run directory.
+
+    Returns:
+        The parsed metadata dict, or None if missing or corrupt.
+    """
+    try:
+        with open(os.path.join(run_dir, METADATA_NAME)) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def find_active_run(
+    results_dir: str,
+    staleness_seconds: float = 120.0,
+    include_test_runs: bool = False,
+) -> str | None:
+    """Find the run directory that is currently being recorded.
+
+    Scans date directories in both the old ``MM.DD`` and new ``YY.MM.DD``
+    naming forms. A run is considered active when its metadata has no
+    ``run_info.end_time`` AND its ``shield_data.csv`` was modified within
+    the last ``staleness_seconds``. ``test_run_*`` directories (recorder
+    test mode) are skipped unless ``include_test_runs`` is True.
+
+    Args:
+        results_dir: Directory containing date-named run subdirectories.
+        staleness_seconds: Maximum age in seconds of the CSV's last write
+            for the run to still count as live.
+        include_test_runs: Also consider ``test_run_*`` directories.
+
+    Returns:
+        Absolute path of the newest active run directory (by CSV mtime),
+        or None if no run is live.
+    """
+    if not os.path.isdir(results_dir):
+        return None
+
+    now = time.time()
+    candidates: list[tuple[float, str]] = []
+
+    for date_name in sorted(os.listdir(results_dir)):
+        date_dir = os.path.join(results_dir, date_name)
+        if not os.path.isdir(date_dir) or not _DATE_DIR_RE.match(date_name):
+            continue
+
+        for run_name in sorted(os.listdir(date_dir)):
+            run_dir = os.path.join(date_dir, run_name)
+            if not os.path.isdir(run_dir) or not _RUN_DIR_RE.match(run_name):
+                continue
+            if run_name.startswith("test_run_") and not include_test_runs:
+                continue
+
+            csv_path = os.path.join(run_dir, DATA_CSV_NAME)
+            if not os.path.isfile(csv_path):
+                continue
+
+            metadata = _read_metadata(run_dir)
+            if metadata is None:
+                continue
+            if metadata.get("run_info", {}).get("end_time"):
+                continue
+
+            mtime = os.path.getmtime(csv_path)
+            if now - mtime > staleness_seconds:
+                continue
+
+            candidates.append((mtime, os.path.abspath(run_dir)))
+
+    if not candidates:
+        return None
+    return max(candidates)[1]
+
+
+class IncrementalRunReader:
+    """Incrementally tail a run's ``shield_data.csv`` without re-reading it.
+
+    The first ``poll()`` parses the CSV header and loads all rows written so
+    far; every subsequent ``poll()`` seeks to the stored byte offset and reads
+    only the newly appended complete lines. A trailing partial line (the
+    recorder may be mid-append) is buffered and completed on a later poll.
+    A missing CSV or a vanished run directory is tolerated: ``poll()`` simply
+    returns 0 new rows.
+
+    Args:
+        run_dir: Path to the run directory containing ``shield_data.csv``.
+
+    Attributes:
+        run_dir: Path to the run directory.
+        csv_path: Path to the tailed CSV file.
+        columns: Column names from the CSV header, or None before the header
+            has been read.
+        data: Mapping of column name to a growing list of values. The
+            ``RealTimestamp`` column holds ``datetime`` objects; every other
+            column holds floats (raw volts, millivolts, or °C as recorded).
+    """
+
+    def __init__(self, run_dir: str):
+        self.run_dir = run_dir
+        self.csv_path = os.path.join(run_dir, DATA_CSV_NAME)
+        self.columns: list[str] | None = None
+        self.data: dict[str, list] = {}
+        self._offset = 0
+        self._partial = ""
+
+    @property
+    def row_count(self) -> int:
+        """Number of complete data rows read so far."""
+        if not self.data:
+            return 0
+        return len(self.data.get(TIMESTAMP_COLUMN, []))
+
+    @property
+    def elapsed_seconds(self) -> float:
+        """Seconds between the first and last timestamps read (0 if <2 rows)."""
+        timestamps = self.data.get(TIMESTAMP_COLUMN, [])
+        if len(timestamps) < 2:
+            return 0.0
+        return (timestamps[-1] - timestamps[0]).total_seconds()
+
+    def poll(self) -> int:
+        """Read any newly appended complete CSV lines.
+
+        Returns:
+            Number of new complete data rows appended to ``data``.
+        """
+        try:
+            with open(self.csv_path, "rb") as f:
+                f.seek(self._offset)
+                chunk = f.read()
+        except OSError:
+            # File not written yet, or the run directory disappeared
+            return 0
+
+        if not chunk:
+            return 0
+        self._offset += len(chunk)
+
+        text = self._partial + chunk.decode("utf-8", errors="replace")
+        lines = text.split("\n")
+        # A chunk not ending in a newline ends with a partial row: buffer it
+        self._partial = "" if text.endswith("\n") else lines[-1]
+        complete_lines = lines[:-1]
+
+        new_rows = 0
+        for line in complete_lines:
+            line = line.strip("\r")
+            if not line.strip():
+                continue
+            if self.columns is None:
+                self.columns = [name.strip() for name in line.split(",")]
+                self.data = {name: [] for name in self.columns}
+                continue
+
+            fields = line.split(",")
+            if len(fields) != len(self.columns):
+                continue  # malformed row
+
+            row_values: dict[str, object] = {}
+            valid = True
+            for column, raw in zip(self.columns, fields):
+                if column == TIMESTAMP_COLUMN:
+                    timestamp = _parse_timestamp(raw.strip())
+                    if timestamp is None:
+                        valid = False
+                        break
+                    row_values[column] = timestamp
+                else:
+                    try:
+                        row_values[column] = float(raw)
+                    except ValueError:
+                        row_values[column] = float("nan")
+            if not valid:
+                continue
+
+            for column, value in row_values.items():
+                self.data[column].append(value)
+            new_rows += 1
+
+        return new_rows
+
+
+def _decimation_indices(n_points: int, max_points: int) -> NDArray:
+    """Stride-based decimation indices that always keep the last point.
+
+    Args:
+        n_points: Number of points available.
+        max_points: Maximum number of points to keep.
+
+    Returns:
+        Sorted array of at most ``max_points`` indices into the data, always
+        including index ``n_points - 1`` (the most recent point).
+    """
+    if n_points <= max_points:
+        return np.arange(n_points)
+    stride = -(-n_points // max_points)  # ceil division
+    # Walk backwards from the newest point so it is always kept
+    return np.arange(n_points - 1, -1, -stride)[::-1]
+
+
+def _convert_gauge_voltage(gauge: dict, voltage_v: NDArray) -> tuple[NDArray, str]:
+    """Convert a gauge voltage trace to pressure using the existing functions.
+
+    Reuses ``WGM701_Gauge.voltage_to_pressure`` and
+    ``CVM211_Gauge.voltage_to_pressure`` (log-scale gauges) and
+    ``analysis.voltage_to_pressure`` (linear Baratron via full scale), exactly
+    as ``Dataset.process_data`` does. Unknown gauge types fall back to raw
+    volts.
+
+    Args:
+        gauge: Gauge metadata dict with ``type`` and, for Baratrons,
+            ``full_scale_torr``.
+        voltage_v: Raw gauge voltages in volts.
+
+    Returns:
+        Tuple of (converted values, unit string): pressures with unit
+        ``"torr"``, or the unchanged voltages with unit ``"V"`` when no
+        conversion is available.
+    """
+    gauge_type = gauge.get("type")
+    if gauge_type == "Baratron626D_Gauge" and gauge.get("full_scale_torr"):
+        pressure_torr = voltage_to_pressure(
+            voltage_v, full_scale_torr=float(gauge["full_scale_torr"])
+        )
+        return pressure_torr, "torr"
+    if gauge_type == "WGM701_Gauge":
+        return WGM701_Gauge().voltage_to_pressure(voltage_v), "torr"
+    if gauge_type == "CVM211_Gauge":
+        return CVM211_Gauge().voltage_to_pressure(voltage_v), "torr"
+    return np.asarray(voltage_v, dtype=float), "V"
+
+
+def build_traces(
+    reader: IncrementalRunReader, metadata: dict, max_points: int
+) -> go.Figure:
+    """Build the three-panel live figure from a reader's current data.
+
+    Panels (shared time axis): upstream pressure (torr, log y), downstream
+    pressure (torr, log y), and temperature (°C, via
+    ``analysis.voltage_to_temperature`` with cold-junction compensation).
+    Gauge columns are mapped through the run metadata, never hardcoded. Each
+    trace is decimated to at most ``max_points`` points (most recent point
+    always kept) so the browser payload stays constant as the run grows.
+    Gauges whose type has no known conversion are plotted as raw volts and
+    labelled accordingly; if a run has no thermocouple the temperature panel
+    shows an annotation instead.
+
+    Args:
+        reader: Reader holding the run's data read so far.
+        metadata: Parsed ``run_metadata.json`` for the run.
+        max_points: Maximum plotted points per trace.
+
+    Returns:
+        Plotly figure with three stacked subplots sharing the x-axis.
+    """
+    fig = make_subplots(
+        rows=3,
+        cols=1,
+        shared_xaxes=True,
+        vertical_spacing=0.06,
+        subplot_titles=(
+            "Upstream pressure",
+            "Downstream pressure",
+            "Temperature",
+        ),
+    )
+
+    timestamps = reader.data.get(TIMESTAMP_COLUMN, [])
+    indices = _decimation_indices(len(timestamps), max_points)
+    x_values = [timestamps[i] for i in indices]
+
+    location_rows = {"upstream": 1, "downstream": 2}
+    row_units: dict[int, set[str]] = {1: set(), 2: set()}
+
+    for gauge in metadata.get("gauges", []):
+        row = location_rows.get(gauge.get("gauge_location"))
+        column = f"{gauge.get('name')}_Voltage (V)"
+        if row is None or column not in reader.data:
+            continue
+        voltage_v = np.asarray(reader.data[column], dtype=float)[indices]
+        values, unit = _convert_gauge_voltage(gauge, voltage_v)
+        row_units[row].add(unit)
+        trace_name = gauge["name"] if unit == "torr" else f"{gauge['name']} (raw V)"
+        fig.add_trace(
+            go.Scattergl(x=x_values, y=values, mode="lines", name=trace_name),
+            row=row,
+            col=1,
+        )
+
+    for row in (1, 2):
+        if row_units[row] == {"V"}:
+            # Only unconverted gauges in this panel: label as raw volts
+            fig.update_yaxes(title_text="Voltage (V)", row=row, col=1)
+        else:
+            fig.update_yaxes(title_text="Pressure (torr)", type="log", row=row, col=1)
+
+    thermocouples = metadata.get("thermocouples", [])
+    local_temp_c = reader.data.get(LOCAL_TEMPERATURE_COLUMN)
+    temperature_plotted = False
+    if local_temp_c is not None:
+        local_array = np.asarray(local_temp_c, dtype=float)[indices]
+        for thermocouple in thermocouples:
+            column = f"{thermocouple.get('name')}_Voltage (mV)"
+            if column not in reader.data:
+                continue
+            tc_voltage_mv = np.asarray(reader.data[column], dtype=float)[indices]
+            temperature_c = voltage_to_temperature(
+                local_temperature=local_array, voltage=tc_voltage_mv
+            )
+            fig.add_trace(
+                go.Scattergl(
+                    x=x_values,
+                    y=temperature_c,
+                    mode="lines",
+                    name=thermocouple.get("name", "thermocouple"),
+                ),
+                row=3,
+                col=1,
+            )
+            temperature_plotted = True
+
+    fig.update_yaxes(title_text="Temperature (°C)", row=3, col=1)
+    if not temperature_plotted:
+        fig.add_annotation(
+            text="no thermocouple in this run",
+            xref="x domain",
+            yref="y domain",
+            x=0.5,
+            y=0.5,
+            showarrow=False,
+            font={"color": "#888888"},
+            row=3,
+            col=1,
+        )
+
+    fig.update_xaxes(title_text="Time", row=3, col=1)
+    fig.update_layout(
+        template="plotly_white",
+        height=850,
+        margin={"l": 60, "r": 20, "t": 40, "b": 40},
+        legend={"orientation": "h", "y": 1.06},
+        uirevision=reader.run_dir,  # keep zoom/pan across interval refreshes
+    )
+    return fig
+
+
+@dataclass
+class LiveDashboardConfig:
+    """Configuration for the live run dashboard.
+
+    Attributes:
+        results_dir: Directory containing recorded runs
+            (``<date>/<run>/`` subdirectories).
+        interval_ms: Refresh interval of the Dash app in milliseconds.
+        max_points: Default maximum plotted points per trace (the fidelity
+            dropdown can override it in the browser).
+        staleness_seconds: A run whose CSV has not been written for this many
+            seconds is no longer considered live.
+        include_test_runs: Also monitor ``test_run_*`` (recorder test mode)
+            directories.
+    """
+
+    results_dir: str = "results"
+    interval_ms: int = 2000
+    max_points: int = 2000
+    staleness_seconds: float = 120.0
+    include_test_runs: bool = False
+
+
+@dataclass
+class DashboardState:
+    """Mutable server-side state of the live dashboard.
+
+    Attributes:
+        run_dir: Path of the run currently displayed, or None.
+        reader: Incremental reader attached to ``run_dir``, or None.
+        metadata: Parsed metadata of the current run.
+        status: One of ``"waiting"``, ``"live"`` or ``"ended"``.
+    """
+
+    run_dir: str | None = None
+    reader: IncrementalRunReader | None = None
+    metadata: dict = field(default_factory=dict)
+    status: str = "waiting"
+
+
+def _run_label(run_dir: str) -> str:
+    """Short display label for a run directory (``<date>/<run>``).
+
+    Args:
+        run_dir: Path to the run directory.
+
+    Returns:
+        The last two path components joined with a slash.
+    """
+    normalised = os.path.normpath(run_dir)
+    date_part = os.path.basename(os.path.dirname(normalised))
+    return f"{date_part}/{os.path.basename(normalised)}"
+
+
+def _format_elapsed(seconds: float) -> str:
+    """Format elapsed seconds as H:MM:SS.
+
+    Args:
+        seconds: Elapsed time in seconds.
+
+    Returns:
+        The formatted duration string.
+    """
+    total = int(seconds)
+    return f"{total // 3600}:{total % 3600 // 60:02d}:{total % 60:02d}"
+
+
+def _waiting_figure(message: str) -> go.Figure:
+    """Placeholder figure shown while no run is live.
+
+    Args:
+        message: Text displayed in the centre of the empty figure.
+
+    Returns:
+        An empty figure with a centred annotation.
+    """
+    fig = go.Figure()
+    fig.add_annotation(
+        text=message,
+        xref="paper",
+        yref="paper",
+        x=0.5,
+        y=0.5,
+        showarrow=False,
+        font={"size": 18, "color": "#888888"},
+    )
+    fig.update_layout(
+        template="plotly_white",
+        height=850,
+        xaxis={"visible": False},
+        yaxis={"visible": False},
+    )
+    return fig
+
+
+def _current_run_has_ended(state: DashboardState, config: LiveDashboardConfig) -> bool:
+    """Check whether the currently displayed run has finished or gone stale.
+
+    Args:
+        state: Current dashboard state.
+        config: Dashboard configuration.
+
+    Returns:
+        True if the run gained an ``end_time``, its CSV went stale, or the
+        run directory disappeared.
+    """
+    if state.run_dir is None:
+        return False
+    metadata = _read_metadata(state.run_dir)
+    if metadata is None:
+        return True  # run directory disappeared
+    if metadata.get("run_info", {}).get("end_time"):
+        return True
+    csv_path = os.path.join(state.run_dir, DATA_CSV_NAME)
+    try:
+        age = time.time() - os.path.getmtime(csv_path)
+    except OSError:
+        return True
+    return age > config.staleness_seconds
+
+
+def _attach_run(state: DashboardState, run_dir: str) -> None:
+    """Point the dashboard state at a new run.
+
+    Args:
+        state: Dashboard state to update in place.
+        run_dir: Path of the run to attach.
+    """
+    state.run_dir = run_dir
+    state.reader = IncrementalRunReader(run_dir)
+    state.metadata = _read_metadata(run_dir) or {}
+    state.status = "live"
+
+
+def update_dashboard(
+    state: DashboardState, config: LiveDashboardConfig, max_points: int
+) -> tuple[go.Figure, str, str, str, str, str]:
+    """Perform one dashboard refresh tick.
+
+    This is the logic behind the interval callback (kept as a module-level
+    function so tests can call it directly). If no run is attached, it looks
+    for one; if the attached run gains an ``end_time`` or goes stale it is
+    marked ENDED and any newer active run is switched to automatically.
+
+    Args:
+        state: Mutable dashboard state, updated in place.
+        config: Dashboard configuration.
+        max_points: Maximum plotted points per trace for this refresh.
+
+    Returns:
+        Tuple of (figure, run label, status text, badge colour, elapsed time
+        text, row count text) matching the callback outputs.
+    """
+    if state.run_dir is not None and _current_run_has_ended(state, config):
+        state.status = "ended"
+
+    if state.reader is None or state.status == "ended":
+        candidate = find_active_run(
+            config.results_dir,
+            staleness_seconds=config.staleness_seconds,
+            include_test_runs=config.include_test_runs,
+        )
+        if candidate is not None and candidate != state.run_dir:
+            _attach_run(state, candidate)
+
+    if state.reader is None:
+        return (
+            _waiting_figure("Waiting for run…"),
+            "Waiting for run…",
+            "WAITING",
+            "secondary",
+            "-",
+            "-",
+        )
+
+    state.reader.poll()
+    figure = build_traces(state.reader, state.metadata, max_points)
+
+    if state.status == "ended":
+        badge_text, badge_colour = "ENDED", "dark"
+    else:
+        badge_text, badge_colour = "LIVE", "success"
+
+    return (
+        figure,
+        _run_label(state.run_dir),
+        badge_text,
+        badge_colour,
+        _format_elapsed(state.reader.elapsed_seconds),
+        f"{state.reader.row_count} rows",
+    )
+
+
+def _create_layout(config: LiveDashboardConfig) -> dbc.Container:
+    """Build the Dash layout for the live dashboard.
+
+    Args:
+        config: Dashboard configuration (sets the refresh interval and the
+            default fidelity).
+
+    Returns:
+        The top-level Bootstrap container.
+    """
+    max_points_options = sorted({*MAX_POINTS_OPTIONS, config.max_points})
+    header = dbc.Row(
+        [
+            dbc.Col(html.H4("SHIELD live run", className="mb-0"), width="auto"),
+            dbc.Col(html.Span(id="live-run-id", className="text-muted"), width="auto"),
+            dbc.Col(
+                dbc.Badge("WAITING", id="live-status-badge", color="secondary"),
+                width="auto",
+            ),
+            dbc.Col(html.Span(id="live-elapsed"), width="auto"),
+            dbc.Col(html.Span(id="live-row-count"), width="auto"),
+            dbc.Col(
+                dcc.Dropdown(
+                    id="live-max-points",
+                    options=[
+                        {"label": f"{n} points", "value": n} for n in max_points_options
+                    ],
+                    value=config.max_points,
+                    clearable=False,
+                    style={"width": "150px"},
+                ),
+                width="auto",
+                className="ms-auto",
+            ),
+        ],
+        align="center",
+        className="g-3 py-2 border-bottom",
+    )
+    return dbc.Container(
+        [
+            header,
+            dcc.Graph(id="live-graph", figure=_waiting_figure("Waiting for run…")),
+            dcc.Interval(id="live-interval", interval=config.interval_ms),
+        ],
+        fluid=True,
+    )
+
+
+def register_live_dashboard_callbacks(
+    app: dash.Dash, config: LiveDashboardConfig, state: DashboardState
+) -> None:
+    """Register the interval refresh callback on the app.
+
+    Args:
+        app: Dash application to register the callback on.
+        config: Dashboard configuration.
+        state: Shared server-side dashboard state.
+    """
+
+    @app.callback(
+        [
+            Output("live-graph", "figure"),
+            Output("live-run-id", "children"),
+            Output("live-status-badge", "children"),
+            Output("live-status-badge", "color"),
+            Output("live-elapsed", "children"),
+            Output("live-row-count", "children"),
+        ],
+        [
+            Input("live-interval", "n_intervals"),
+            Input("live-max-points", "value"),
+        ],
+    )
+    def refresh_dashboard(n_intervals, max_points):
+        """Interval-driven refresh of the whole dashboard.
+
+        Args:
+            n_intervals: Number of interval ticks so far (unused trigger).
+            max_points: Fidelity dropdown value (max plotted points/trace).
+
+        Returns:
+            tuple: (figure, run label, status text, badge colour, elapsed
+            time text, row count text)
+        """
+        return update_dashboard(state, config, int(max_points or config.max_points))
+
+
+def create_app(config: LiveDashboardConfig) -> dash.Dash:
+    """Create the live dashboard Dash application.
+
+    Args:
+        config: Dashboard configuration.
+
+    Returns:
+        The configured Dash app; its shared state is exposed as
+        ``app.live_state`` for inspection.
+    """
+    app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
+    app.title = "SHIELD live run"
+    state = DashboardState()
+    app.layout = _create_layout(config)
+    register_live_dashboard_callbacks(app, config, state)
+    app.live_state = state
+    return app
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the live run dashboard (``shield-das-live``).
+
+    Serves the dashboard on ``--host``/``--port``. The default host
+    ``0.0.0.0`` binds all interfaces, which exposes the dashboard to the
+    LAN/tailnet — that is the intended remote-monitoring path (view the same
+    URL from another machine via Tailscale or the lab network). Use
+    ``--host 127.0.0.1`` to keep it local-only. The browser is always opened
+    toward ``http://127.0.0.1:<port>`` regardless of the bind host.
+
+    Args:
+        argv: Command-line arguments (defaults to sys.argv).
+
+    Returns:
+        Process exit code (0 on success, 1 if no run is live and ``--watch``
+        was not given).
+    """
+    parser = argparse.ArgumentParser(
+        prog="shield-das-live",
+        description="Live dashboard for the run currently being recorded.",
+    )
+    parser.add_argument(
+        "--results-dir",
+        default="results",
+        help="Directory containing recorded runs (default: results)",
+    )
+    parser.add_argument(
+        "--port", type=int, default=8051, help="Port to serve on (default: 8051)"
+    )
+    parser.add_argument(
+        "--host",
+        default="0.0.0.0",
+        help=(
+            "Interface to bind (default: 0.0.0.0, which exposes the dashboard "
+            "to the LAN/tailnet for remote monitoring)"
+        ),
+    )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=2000,
+        help="Refresh interval in milliseconds (default: 2000)",
+    )
+    parser.add_argument(
+        "--max-points",
+        type=int,
+        default=2000,
+        help="Default maximum plotted points per trace (default: 2000)",
+    )
+    parser.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Do not open a web browser",
+    )
+    parser.add_argument(
+        "--watch",
+        action="store_true",
+        help=(
+            "Poll every 10 s until an active run appears instead of exiting "
+            "when nothing is live"
+        ),
+    )
+    parser.add_argument(
+        "--include-test-runs",
+        action="store_true",
+        help="Also monitor test_run_* (recorder test mode) directories",
+    )
+    args = parser.parse_args(argv)
+
+    config = LiveDashboardConfig(
+        results_dir=args.results_dir,
+        interval_ms=args.interval,
+        max_points=args.max_points,
+        include_test_runs=args.include_test_runs,
+    )
+
+    active_run = find_active_run(
+        config.results_dir,
+        staleness_seconds=config.staleness_seconds,
+        include_test_runs=config.include_test_runs,
+    )
+    if active_run is None:
+        if not args.watch:
+            print(
+                f"No live run found under {config.results_dir!r}. Start the "
+                "recorder first, or use --watch to wait for one."
+            )
+            return 1
+        print(f"Watching {config.results_dir!r} for a live run (every 10 s)...")
+        while active_run is None:
+            time.sleep(10)
+            active_run = find_active_run(
+                config.results_dir,
+                staleness_seconds=config.staleness_seconds,
+                include_test_runs=config.include_test_runs,
+            )
+
+    print(f"Live run: {active_run}")
+    print(f"Serving dashboard on http://{args.host}:{args.port}")
+
+    app = create_app(config)
+
+    if not args.no_browser:
+        # Always point the local browser at the loopback address, whatever
+        # interface the server binds
+        threading.Timer(
+            0.5, lambda: webbrowser.open(f"http://127.0.0.1:{args.port}")
+        ).start()
+
+    app.run(host=args.host, port=args.port, debug=False)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -193,8 +193,9 @@ def test_expected_export_count():
     """Test that we have the expected number of exports."""
     import shield_das
 
-    # 8 analysis functions + 8 core classes/gauges + 5 uploader = 21 total
-    expected_count = 21
+    # 8 analysis functions + 8 core classes/gauges + 5 uploader
+    # + 7 live dashboard = 28 total
+    expected_count = 28
     actual_count = len(shield_das.__all__)
 
     assert actual_count == expected_count, (

--- a/test/test_live_dashboard.py
+++ b/test/test_live_dashboard.py
@@ -1,0 +1,538 @@
+"""Tests for the live run dashboard.
+
+Covers active-run discovery, incremental CSV tailing (offset-based, with
+partial-line buffering), stride decimation, metadata-driven trace building,
+and the waiting -> live -> ended callback transitions. No hardware, no
+network, and no real Dash server are used.
+"""
+
+import json
+import os
+import shutil
+from datetime import datetime, timedelta
+
+import numpy as np
+import pytest
+
+from shield_das.live_dashboard import (
+    DashboardState,
+    IncrementalRunReader,
+    LiveDashboardConfig,
+    _decimation_indices,
+    build_traces,
+    find_active_run,
+    update_dashboard,
+)
+
+# =============================================================================
+# Helpers for building fake run directories
+# =============================================================================
+
+GAUGES = [
+    {
+        "name": "Baratron626D_1KT",
+        "type": "Baratron626D_Gauge",
+        "gauge_location": "upstream",
+        "full_scale_torr": 1000,
+    },
+    {
+        "name": "Baratron626D_1T",
+        "type": "Baratron626D_Gauge",
+        "gauge_location": "downstream",
+        "full_scale_torr": 1,
+    },
+    {
+        "name": "CVM211",
+        "type": "CVM211_Gauge",
+        "gauge_location": "upstream",
+    },
+    {
+        "name": "WGM701",
+        "type": "WGM701_Gauge",
+        "gauge_location": "downstream",
+    },
+]
+
+THERMOCOUPLES = [{"name": "TC1"}]
+
+
+def csv_header(gauges, thermocouples):
+    """Build the CSV header line for the given instruments."""
+    columns = ["RealTimestamp"]
+    if thermocouples:
+        columns.append("Local_temperature (C)")
+        columns += [f"{t['name']}_Voltage (mV)" for t in thermocouples]
+    columns += [f"{g['name']}_Voltage (V)" for g in gauges]
+    return ",".join(columns)
+
+
+def csv_row(row_index, gauges, thermocouples, voltage_v=5.0):
+    """Build one CSV data row with a timestamp 0.5 s apart per row."""
+    timestamp = datetime(2026, 8, 4, 10, 0, 0) + timedelta(seconds=0.5 * row_index)
+    fields = [timestamp.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]]
+    if thermocouples:
+        fields.append("25.0")  # Local_temperature (C)
+        fields += ["1.0" for _ in thermocouples]  # thermocouple mV
+    fields += [str(voltage_v) for _ in gauges]
+    return ",".join(fields)
+
+
+def make_run(
+    results_dir,
+    date_name="26.08.04",
+    run_name="run_1_10h00",
+    n_rows=5,
+    gauges=GAUGES,
+    thermocouples=THERMOCOUPLES,
+    end_time=None,
+):
+    """Create a fake run directory with metadata and CSV; return its path."""
+    run_dir = os.path.join(str(results_dir), date_name, run_name)
+    os.makedirs(run_dir, exist_ok=True)
+
+    run_info = {"date": "2026-08-04", "start_time": "2026-08-04 10:00:00"}
+    if end_time is not None:
+        run_info["end_time"] = end_time
+    metadata = {"version": "1.3", "run_info": run_info, "gauges": gauges}
+    if thermocouples:
+        metadata["thermocouples"] = thermocouples
+    with open(os.path.join(run_dir, "run_metadata.json"), "w") as f:
+        json.dump(metadata, f)
+
+    lines = [csv_header(gauges, thermocouples)]
+    lines += [csv_row(i, gauges, thermocouples) for i in range(n_rows)]
+    with open(os.path.join(run_dir, "shield_data.csv"), "w") as f:
+        f.write("\n".join(lines) + "\n")
+
+    return run_dir
+
+
+def make_stale(run_dir, age_seconds=3600):
+    """Backdate the run's CSV mtime by age_seconds."""
+    csv_path = os.path.join(run_dir, "shield_data.csv")
+    old = os.path.getmtime(csv_path) - age_seconds
+    os.utime(csv_path, (old, old))
+
+
+# =============================================================================
+# Tests for find_active_run
+# =============================================================================
+
+
+def test_find_active_run_returns_fresh_run_without_end_time(tmp_path):
+    """A run with no end_time and a fresh CSV is found."""
+    run_dir = make_run(tmp_path)
+
+    assert find_active_run(str(tmp_path)) == run_dir
+
+
+def test_find_active_run_excludes_run_with_end_time(tmp_path):
+    """A run whose metadata has end_time is not live."""
+    make_run(tmp_path, end_time="2026-08-04 11:00:00")
+
+    assert find_active_run(str(tmp_path)) is None
+
+
+def test_find_active_run_excludes_stale_csv(tmp_path):
+    """A run whose CSV mtime is older than staleness_seconds is not live."""
+    run_dir = make_run(tmp_path)
+    make_stale(run_dir, age_seconds=3600)
+
+    assert find_active_run(str(tmp_path), staleness_seconds=120) is None
+
+
+def test_find_active_run_supports_old_date_dir_format(tmp_path):
+    """Old-style MM.DD date directories are scanned too."""
+    run_dir = make_run(tmp_path, date_name="08.04")
+
+    assert find_active_run(str(tmp_path)) == run_dir
+
+
+def test_find_active_run_skips_test_runs_by_default(tmp_path):
+    """test_run_* directories are skipped unless include_test_runs is set."""
+    run_dir = make_run(tmp_path, run_name="test_run_1_10h00")
+
+    assert find_active_run(str(tmp_path)) is None
+    assert find_active_run(str(tmp_path), include_test_runs=True) == run_dir
+
+
+def test_find_active_run_returns_newest_of_multiple(tmp_path):
+    """With two live runs, the one with the newest CSV wins."""
+    older = make_run(tmp_path, run_name="run_1_09h00")
+    newer = make_run(tmp_path, run_name="run_2_10h00")
+    make_stale(older, age_seconds=60)  # still fresh, but older than run_2
+
+    assert find_active_run(str(tmp_path)) == newer
+
+
+def test_find_active_run_missing_results_dir_returns_none(tmp_path):
+    """A nonexistent results directory yields None, not an error."""
+    assert find_active_run(str(tmp_path / "nope")) is None
+
+
+def test_find_active_run_ignores_non_run_directories(tmp_path):
+    """Directories not matching the date/run naming are ignored."""
+    os.makedirs(tmp_path / "not_a_date" / "run_1_10h00")
+    os.makedirs(tmp_path / "26.08.04" / "not_a_run")
+
+    assert find_active_run(str(tmp_path)) is None
+
+
+# =============================================================================
+# Tests for IncrementalRunReader
+# =============================================================================
+
+
+def test_reader_initial_load_parses_header_and_rows(tmp_path):
+    """First poll reads the header and all existing rows."""
+    run_dir = make_run(tmp_path, n_rows=4)
+    reader = IncrementalRunReader(run_dir)
+
+    assert reader.poll() == 4
+    assert reader.row_count == 4
+    assert "RealTimestamp" in reader.columns
+    assert "Baratron626D_1KT_Voltage (V)" in reader.columns
+    assert reader.data["Baratron626D_1KT_Voltage (V)"] == [5.0, 5.0, 5.0, 5.0]
+    assert isinstance(reader.data["RealTimestamp"][0], datetime)
+    # 4 rows spaced 0.5 s apart -> 1.5 s elapsed
+    assert reader.elapsed_seconds == pytest.approx(1.5)
+
+
+def test_reader_incremental_poll_reads_only_new_bytes(tmp_path):
+    """After the initial load, poll only consumes newly appended bytes."""
+    run_dir = make_run(tmp_path, n_rows=3)
+    csv_path = os.path.join(run_dir, "shield_data.csv")
+    reader = IncrementalRunReader(run_dir)
+    reader.poll()
+
+    size_after_first = os.path.getsize(csv_path)
+    assert reader._offset == size_after_first  # everything consumed
+
+    with open(csv_path, "a") as f:
+        f.write(csv_row(3, GAUGES, THERMOCOUPLES) + "\n")
+
+    assert reader.poll() == 1  # exactly one new row
+    # Offset advanced by exactly the appended bytes: nothing was re-read
+    assert reader._offset == os.path.getsize(csv_path)
+    assert reader._offset > size_after_first
+    assert reader.row_count == 4
+
+    # A poll with no new data reads nothing
+    assert reader.poll() == 0
+    assert reader._offset == os.path.getsize(csv_path)
+
+
+def test_reader_buffers_partial_line(tmp_path):
+    """A half-written row is buffered and completed by a later poll."""
+    run_dir = make_run(tmp_path, n_rows=2)
+    csv_path = os.path.join(run_dir, "shield_data.csv")
+    reader = IncrementalRunReader(run_dir)
+    reader.poll()
+
+    full_row = csv_row(2, GAUGES, THERMOCOUPLES)
+    half = len(full_row) // 2
+    with open(csv_path, "a") as f:
+        f.write(full_row[:half])
+
+    assert reader.poll() == 0  # incomplete row is not consumed
+    assert reader.row_count == 2
+
+    with open(csv_path, "a") as f:
+        f.write(full_row[half:] + "\n")
+
+    assert reader.poll() == 1
+    assert reader.row_count == 3
+    # The stitched row parsed correctly
+    assert reader.data["WGM701_Voltage (V)"][-1] == 5.0
+
+
+def test_reader_handles_missing_csv(tmp_path):
+    """Polling before the CSV exists returns 0 rows without raising."""
+    run_dir = str(tmp_path / "26.08.04" / "run_1_10h00")
+    os.makedirs(run_dir)
+    reader = IncrementalRunReader(run_dir)
+
+    assert reader.poll() == 0
+    assert reader.row_count == 0
+
+
+def test_reader_handles_run_dir_disappearing(tmp_path):
+    """Polling after the run directory is deleted returns 0 rows."""
+    run_dir = make_run(tmp_path, n_rows=2)
+    reader = IncrementalRunReader(run_dir)
+    reader.poll()
+
+    shutil.rmtree(run_dir)
+
+    assert reader.poll() == 0
+    assert reader.row_count == 2  # previously read data is retained
+
+
+def test_reader_skips_malformed_rows(tmp_path):
+    """Rows with the wrong number of fields are skipped."""
+    run_dir = make_run(tmp_path, n_rows=1)
+    csv_path = os.path.join(run_dir, "shield_data.csv")
+    reader = IncrementalRunReader(run_dir)
+    reader.poll()
+
+    with open(csv_path, "a") as f:
+        f.write("garbage,line\n")
+        f.write(csv_row(1, GAUGES, THERMOCOUPLES) + "\n")
+
+    assert reader.poll() == 1
+    assert reader.row_count == 2
+
+
+# =============================================================================
+# Tests for _decimation_indices
+# =============================================================================
+
+
+def test_decimation_keeps_all_points_when_under_cap():
+    """No decimation happens when n <= max_points."""
+    indices = _decimation_indices(100, 500)
+
+    assert len(indices) == 100
+    assert list(indices) == list(range(100))
+
+
+@pytest.mark.parametrize("n_points", [501, 1000, 1234, 9999, 100000])
+def test_decimation_respects_cap(n_points):
+    """Decimated traces never exceed max_points."""
+    indices = _decimation_indices(n_points, 500)
+
+    assert len(indices) <= 500
+
+
+@pytest.mark.parametrize("n_points", [1, 499, 500, 501, 1234, 100000])
+def test_decimation_always_keeps_last_point(n_points):
+    """The most recent point is always retained."""
+    indices = _decimation_indices(n_points, 500)
+
+    assert indices[-1] == n_points - 1
+    assert list(indices) == sorted(set(indices))  # strictly increasing
+
+
+# =============================================================================
+# Tests for build_traces
+# =============================================================================
+
+
+def loaded_reader(tmp_path, **kwargs):
+    """Create a run, attach a reader and load it."""
+    run_dir = make_run(tmp_path, **kwargs)
+    reader = IncrementalRunReader(run_dir)
+    reader.poll()
+    metadata = json.load(open(os.path.join(run_dir, "run_metadata.json")))
+    return reader, metadata
+
+
+def trace_names_by_row(fig):
+    """Map subplot row (via yaxis) to trace names."""
+    mapping = {}
+    for trace in fig.data:
+        mapping.setdefault(trace.yaxis, []).append(trace.name)
+    return mapping
+
+
+def test_build_traces_splits_gauges_by_location(tmp_path):
+    """Upstream gauges land in panel 1, downstream in panel 2."""
+    reader, metadata = loaded_reader(tmp_path)
+    fig = build_traces(reader, metadata, max_points=500)
+
+    by_row = trace_names_by_row(fig)
+    assert sorted(by_row["y"]) == ["Baratron626D_1KT", "CVM211"]
+    assert sorted(by_row["y2"]) == ["Baratron626D_1T", "WGM701"]
+    assert by_row["y3"] == ["TC1"]
+
+
+def test_build_traces_converts_voltages_per_gauge_type(tmp_path):
+    """Each gauge type uses its own voltage-to-pressure conversion."""
+    reader, metadata = loaded_reader(tmp_path)
+    fig = build_traces(reader, metadata, max_points=500)
+
+    traces = {t.name: t for t in fig.data}
+    # Baratron (linear): 5 V on a 1000 torr full scale -> 500 torr
+    assert traces["Baratron626D_1KT"].y[0] == pytest.approx(500.0)
+    # Baratron 1 torr full scale (linear): 5 V * (1/10) = 0.5 torr
+    assert traces["Baratron626D_1T"].y[0] == pytest.approx(0.5)
+    # CVM211 (log): 10^(5 - 5) = 1 torr
+    assert traces["CVM211"].y[0] == pytest.approx(1.0)
+    # WGM701 (log): 10^((5 - 5.5)/0.5) = 0.1 torr
+    assert traces["WGM701"].y[0] == pytest.approx(0.1)
+
+
+def test_build_traces_pressure_axes_are_log_torr(tmp_path):
+    """Pressure panels use log axes labelled in torr."""
+    reader, metadata = loaded_reader(tmp_path)
+    fig = build_traces(reader, metadata, max_points=500)
+
+    assert fig.layout.yaxis.type == "log"
+    assert fig.layout.yaxis.title.text == "Pressure (torr)"
+    assert fig.layout.yaxis2.type == "log"
+    assert fig.layout.yaxis2.title.text == "Pressure (torr)"
+    assert fig.layout.yaxis3.title.text == "Temperature (°C)"
+
+
+def test_build_traces_temperature_uses_cold_junction_conversion(tmp_path):
+    """The temperature trace comes from voltage_to_temperature."""
+    from shield_das.analysis import voltage_to_temperature
+
+    reader, metadata = loaded_reader(tmp_path)
+    fig = build_traces(reader, metadata, max_points=500)
+
+    expected = voltage_to_temperature(np.array([25.0]), np.array([1.0]))[0]
+    traces = {t.name: t for t in fig.data}
+    assert traces["TC1"].y[0] == pytest.approx(expected)
+
+
+def test_build_traces_no_thermocouple_annotation(tmp_path):
+    """A run without thermocouples gets an annotation, not a trace."""
+    reader, metadata = loaded_reader(tmp_path, thermocouples=[])
+    fig = build_traces(reader, metadata, max_points=500)
+
+    assert "y3" not in trace_names_by_row(fig)
+    annotations = [a.text for a in fig.layout.annotations]
+    assert "no thermocouple in this run" in annotations
+
+
+def test_build_traces_unknown_gauge_type_falls_back_to_raw_volts(tmp_path):
+    """An unknown gauge type is plotted as raw volts with a labelled axis."""
+    gauges = [{"name": "Mystery", "type": "FutureGauge", "gauge_location": "upstream"}]
+    reader, metadata = loaded_reader(tmp_path, gauges=gauges, thermocouples=[])
+    fig = build_traces(reader, metadata, max_points=500)
+
+    traces = {t.name: t for t in fig.data}
+    assert traces["Mystery (raw V)"].y[0] == pytest.approx(5.0)
+    assert fig.layout.yaxis.title.text == "Voltage (V)"
+    assert fig.layout.yaxis.type != "log"
+
+
+def test_build_traces_decimates_to_max_points(tmp_path):
+    """Traces are decimated to the cap and keep the newest sample."""
+    reader, metadata = loaded_reader(tmp_path, n_rows=250)
+    last_timestamp = reader.data["RealTimestamp"][-1]
+    fig = build_traces(reader, metadata, max_points=100)
+
+    for trace in fig.data:
+        assert len(trace.y) <= 100
+        assert trace.x[-1] == last_timestamp
+
+
+# =============================================================================
+# Tests for the interval callback logic (update_dashboard called directly)
+# =============================================================================
+
+
+def test_update_dashboard_waiting_when_no_run(tmp_path):
+    """With no active run the dashboard reports WAITING."""
+    state = DashboardState()
+    config = LiveDashboardConfig(results_dir=str(tmp_path))
+
+    _figure, label, badge, colour, _elapsed, _rows = update_dashboard(
+        state, config, max_points=500
+    )
+
+    assert badge == "WAITING"
+    assert colour == "secondary"
+    assert state.reader is None
+    assert "Waiting" in label
+
+
+def test_update_dashboard_attaches_to_live_run(tmp_path):
+    """A live run is discovered and reported as LIVE with its data loaded."""
+    run_dir = make_run(tmp_path, n_rows=6)
+    state = DashboardState()
+    config = LiveDashboardConfig(results_dir=str(tmp_path))
+
+    figure, label, badge, colour, _elapsed, rows = update_dashboard(
+        state, config, max_points=500
+    )
+
+    assert badge == "LIVE"
+    assert colour == "success"
+    assert state.run_dir == run_dir
+    assert label == "26.08.04/run_1_10h00"
+    assert rows == "6 rows"
+    assert len(figure.data) > 0
+
+
+def test_update_dashboard_marks_run_ended_on_end_time(tmp_path):
+    """When the run gains an end_time the badge switches to ENDED."""
+    run_dir = make_run(tmp_path)
+    state = DashboardState()
+    config = LiveDashboardConfig(results_dir=str(tmp_path))
+    update_dashboard(state, config, max_points=500)
+
+    metadata_path = os.path.join(run_dir, "run_metadata.json")
+    metadata = json.load(open(metadata_path))
+    metadata["run_info"]["end_time"] = "2026-08-04 11:00:00"
+    with open(metadata_path, "w") as f:
+        json.dump(metadata, f)
+
+    _figure, label, badge, colour, _elapsed, _rows = update_dashboard(
+        state, config, max_points=500
+    )
+
+    assert badge == "ENDED"
+    assert colour == "dark"
+    assert label == "26.08.04/run_1_10h00"  # last run still shown
+
+
+def test_update_dashboard_marks_run_ended_when_stale(tmp_path):
+    """A run whose CSV stops updating goes ENDED after staleness_seconds."""
+    run_dir = make_run(tmp_path)
+    state = DashboardState()
+    config = LiveDashboardConfig(results_dir=str(tmp_path), staleness_seconds=120)
+    update_dashboard(state, config, max_points=500)
+
+    make_stale(run_dir, age_seconds=3600)
+
+    _figure, _label, badge, colour, _elapsed, _rows = update_dashboard(
+        state, config, max_points=500
+    )
+
+    assert badge == "ENDED"
+    assert colour == "dark"
+
+
+def test_update_dashboard_switches_to_newer_run_after_end(tmp_path):
+    """After the current run ends, a newer active run is picked up."""
+    make_run(tmp_path, run_name="run_1_09h00", end_time="2026-08-04 09:30:00")
+    first = make_run(tmp_path, run_name="run_2_10h00")
+    state = DashboardState()
+    config = LiveDashboardConfig(results_dir=str(tmp_path))
+    update_dashboard(state, config, max_points=500)
+    assert state.run_dir == first
+
+    # End the current run and start a newer one
+    metadata_path = os.path.join(first, "run_metadata.json")
+    metadata = json.load(open(metadata_path))
+    metadata["run_info"]["end_time"] = "2026-08-04 10:30:00"
+    with open(metadata_path, "w") as f:
+        json.dump(metadata, f)
+    newer = make_run(tmp_path, run_name="run_3_11h00", n_rows=2)
+
+    _figure, label, badge, _colour, _elapsed, rows = update_dashboard(
+        state, config, max_points=500
+    )
+
+    assert state.run_dir == newer
+    assert badge == "LIVE"
+    assert label == "26.08.04/run_3_11h00"
+    assert rows == "2 rows"
+
+
+def test_update_dashboard_polls_new_rows_between_ticks(tmp_path):
+    """New CSV rows written between ticks appear in the next refresh."""
+    run_dir = make_run(tmp_path, n_rows=3)
+    state = DashboardState()
+    config = LiveDashboardConfig(results_dir=str(tmp_path))
+    update_dashboard(state, config, max_points=500)
+
+    with open(os.path.join(run_dir, "shield_data.csv"), "a") as f:
+        f.write(csv_row(3, GAUGES, THERMOCOUPLES) + "\n")
+
+    *_first, rows = update_dashboard(state, config, max_points=500)
+
+    assert rows == "4 rows"


### PR DESCRIPTION
## What

A lightweight live dashboard for the run currently being recorded, served by a new console script `shield-das-live`. It auto-discovers the active run under `results/`, tails its `shield_data.csv` incrementally, and shows three stacked, time-shared panels: upstream pressure (torr, log), downstream pressure (torr, log), and temperature (°C). A header bar shows run id, LIVE/WAITING/ENDED badge, elapsed time, row count, and a fidelity dropdown (500/2000/5000 max points).

## How

- **`find_active_run(results_dir, staleness_seconds=120)`** — scans both `MM.DD` and `YY.MM.DD` date dirs; a run is live when its metadata has no `run_info.end_time` and its CSV was written within the staleness window. `test_run_*` dirs are skipped unless `--include-test-runs` (useful for demoing without hardware via `run_type="test_mode"`).
- **`IncrementalRunReader`** — first `poll()` parses the header and existing rows; later polls seek to the stored byte offset and read only newly appended complete lines, buffering any half-written trailing line. The CSV is never re-read after the initial load (the `DataPlotter` full-reparse-every-second pattern is deliberately avoided). Column parsing is driven entirely by the CSV header + metadata.
- **`build_traces(reader, metadata, max_points)`** — reuses the existing conversions: `WGM701_Gauge.voltage_to_pressure` and `CVM211_Gauge.voltage_to_pressure` (log-scale gauges), `analysis.voltage_to_pressure` with `full_scale_torr` for Baratrons (as `Dataset.process_data` does), and `analysis.voltage_to_temperature` (cold-junction compensated) for thermocouples. Unknown gauge types fall back to raw volts with a labelled axis; runs without a thermocouple get a "no thermocouple in this run" annotation. Stride decimation always keeps the most recent point, so browser payload per refresh is constant regardless of run size — that plus the incremental reads is the remote-monitoring efficiency story.
- **Interval callback** — `update_dashboard()` is a module-level function (existing callback-testing pattern) handling waiting → live → ended transitions and automatic switch-over to a newer active run.
- **CLI** — `--results-dir`, `--port` (8051), `--host` (0.0.0.0 by default, exposing the dashboard to the LAN/tailnet for remote viewing), `--interval`, `--max-points`, `--no-browser`, `--watch` (poll every 10 s until a run appears), `--include-test-runs`. The browser is opened at `http://127.0.0.1:<port>` regardless of bind host.

## Docs

`docs/live_dashboard.md` (entry point, Windows logon `schtasks` example, remote viewing over Tailscale/LAN, efficiency notes), linked from `README.md`, plus a short in-progress-vs-completed cross-reference in `docs/auto_upload.md`.

## Testing

- 39 new unit tests in `test/test_live_dashboard.py` (no hardware, no network, no real Dash server): discovery filters, incremental/offset reads, partial-line buffering, decimation cap + last-point guarantees, metadata-driven trace mapping, and the callback state transitions. Full run alongside `test_data_recorder.py`: 137 passed.
- End-to-end sanity check: recorder in `test_mode` generated a live `test_run_*`; `shield-das-live` served it on a spare port (`curl` → HTTP 200, title present) and two direct callback ticks showed LIVE with the row count growing (79 → 88 rows, 5 traces); server and recorder cleaned up after.
- `ruff format` + `ruff check` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)