### PR TITLE
Declare pytz dependency (plotly-resampler imports it undeclared)

### DIFF
--- a/.github/workflows/code_formatting.yml
+++ b/.github/workflows/code_formatting.yml
@@ -13,7 +13,10 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install linting tools
-        run: pip install mypy ruff
+        # ruff pinned: an unpinned latest changed behaviour mid-project
+        # (0.16 format-checks Python blocks inside markdown) and broke CI
+        # for every open branch at once. Bump deliberately.
+        run: pip install mypy ruff==0.16.1
 
       - name: ruff format
         run: |

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ from shield_das import voltage_to_temperature
 import numpy as np
 
 tc_voltage_mv = np.array([10.0, 20.0, 30.0])  # millivolts
-local_temp_c = np.array([25.0, 25.0, 25.0])   # cold junction temp
+local_temp_c = np.array([25.0, 25.0, 25.0])  # cold junction temp
 
 temperature = voltage_to_temperature(local_temp_c, tc_voltage_mv)
 print(temperature)  # [270.7, 508.3, 744.9] °C

--- a/README.md
+++ b/README.md
@@ -24,12 +24,7 @@ However, in order to interact with the Labjack, additional drivers are required 
 This is an example of a script that can be used to activate the DAS.
 
 ```python
-from shield_das import (
-    DataRecorder,
-    WGM701_Gauge,
-    CVM211_Gauge,
-    Baratron626D_Gauge
-)
+from shield_das import DataRecorder, WGM701_Gauge, CVM211_Gauge, Baratron626D_Gauge
 
 # Define gauges
 gauge_1 = WGM701_Gauge(
@@ -65,13 +60,11 @@ my_recorder = DataRecorder(
 
 # Start recording
 my_recorder.run()
-
 ```
 
 ## Example data visualisation script
 
 ```python
-
 from shield_das import DataPlotter
 
 data_500C_run1 = "results/25.08.12/run_2_11h45/"
@@ -84,7 +77,6 @@ my_plotter = DataPlotter(
     dataset_names=["500C_run1", "500C_run2", "500C_run3", "500C_run4"],
 )
 my_plotter.start()
-
 ```
 
 ## Standalone Analysis Functions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,9 @@ requires-python = ">=3.9"
 license = { file = "LICENSE" }
 # pytz: imported by plotly-resampler but missing from its dependency metadata;
 # pandas 3 stopped providing it transitively, breaking fresh installs.
-dependencies = ["LabJackPython", "numpy", "dash", "dash_bootstrap_components", "pandas", "keyboard", "plotly-resampler", "h-transport-materials", "uncertainties", "pytz"]
+# setuptools: pybtex (via h-transport-materials) imports pkg_resources, which
+# setuptools >= 81 no longer ships by default on new Pythons.
+dependencies = ["LabJackPython", "numpy", "dash", "dash_bootstrap_components", "pandas", "keyboard", "plotly-resampler", "h-transport-materials", "uncertainties", "pytz", "setuptools"]
 classifiers = [
     "Natural Language :: English",
     "Topic :: Scientific/Engineering",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,9 @@ description = "SHIELD permeation rig data aquisition system"
 readme = "README.md"
 requires-python = ">=3.9"
 license = { file = "LICENSE" }
-dependencies = ["LabJackPython", "numpy", "dash", "dash_bootstrap_components", "pandas", "keyboard", "plotly-resampler", "h-transport-materials", "uncertainties"]
+# pytz: imported by plotly-resampler but missing from its dependency metadata;
+# pandas 3 stopped providing it transitively, breaking fresh installs.
+dependencies = ["LabJackPython", "numpy", "dash", "dash_bootstrap_components", "pandas", "keyboard", "plotly-resampler", "h-transport-materials", "uncertainties", "pytz"]
 classifiers = [
     "Natural Language :: English",
     "Topic :: Scientific/Engineering",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,9 @@ requires-python = ">=3.9"
 license = { file = "LICENSE" }
 # pytz: imported by plotly-resampler but missing from its dependency metadata;
 # pandas 3 stopped providing it transitively, breaking fresh installs.
-# setuptools: pybtex (via h-transport-materials) imports pkg_resources, which
-# setuptools >= 81 no longer ships by default on new Pythons.
-dependencies = ["LabJackPython", "numpy", "dash", "dash_bootstrap_components", "pandas", "keyboard", "plotly-resampler", "h-transport-materials", "uncertainties", "pytz", "setuptools"]
+# setuptools<81: pybtex (via h-transport-materials) imports pkg_resources,
+# which newer setuptools removed; 80.x is the last line that ships it.
+dependencies = ["LabJackPython", "numpy", "dash", "dash_bootstrap_components", "pandas", "keyboard", "plotly-resampler", "h-transport-materials", "uncertainties", "pytz", "setuptools<81"]
 classifiers = [
     "Natural Language :: English",
     "Topic :: Scientific/Engineering",


### PR DESCRIPTION
plotly_resampler imports pytz directly but relied on pandas providing it
transitively; pandas 3 dropped pytz, so fresh CI environments fail every
test module at import. main has been red since 2026-08-03.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
